### PR TITLE
Add GitHub Actions CI for testing and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run linter
+        run: |
+          pip install ruff
+          ruff check .
+
+      - name: Run tests
+        run: python -m pytest tests/ -v


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with GitHub Actions workflow
- Run backend pytest and ruff linting on PRs and pushes to main
- Uses Python 3.10 to match the backend Dockerfile

## Test plan
- [ ] Workflow triggers on PR to main
- [ ] pytest runs successfully in CI
- [ ] ruff linting runs successfully in CI

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)