### PR TITLE
Add .dockerignore files to optimize Docker builds

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.venv
+venv/
+*.md
+.pytest_cache/
+static/

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+.git
+.gitignore
+.env
+*.md
+.svelte-kit/
+build/
+dist/


### PR DESCRIPTION
## Summary
- Add `backend/.dockerignore` to exclude __pycache__, .git, .env, static/, etc.
- Add `frontend/.dockerignore` to exclude node_modules/, .git, .svelte-kit/, etc.
- Reduces Docker build context size and prevents unnecessary files in images

## Test plan
- [ ] Docker build still works correctly for both services
- [ ] Excluded files are not present in built images

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)