### PR TITLE
Fix: Remove unused os import in test_main.py

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,4 +1,3 @@
-import os
 import base64
 import pytest
 from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## Summary
Fixes CI lint failure by removing unused `import os` in `backend/tests/test_main.py`.

## Issue
GitHub Actions CI was failing with ruff lint error:
```
F401 [*] `os` imported but unused
 --> tests/test_main.py:1:8
```

## Changes
- Removed `import os` from line 1
- The `os` module is only referenced in `@patch` decorators as strings (e.g., `@patch("main.os.makedirs")`), so the import is not needed

## Testing
- [x] Ruff lint check should now pass
- [x] Existing tests remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)