### PR TITLE
feat: fix frontend Dockerfile for Docker setup

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,3 +2,4 @@ FROM node:18-alpine
 WORKDIR /home/app
 COPY package*.json ./
 RUN npm install
+COPY ./ ./

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "frontend",
+  "name": "image-to-svg",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend",
+      "name": "image-to-svg",
       "version": "0.0.1",
       "dependencies": {
         "file-saver": "^2.0.5",


### PR DESCRIPTION
## Summary
- Add missing `COPY ./ ./` step to frontend Dockerfile so the container image includes source code and doesn't rely solely on volume mounts
- Verify Docker environment works correctly with `its-backend` and `its-frontend` containers

## Test plan
- [x] `docker compose build` succeeds
- [x] `docker compose up -d` starts both containers
- [x] Backend health check returns `{"status": "healthy"}`
- [x] Frontend responds with HTTP 200
- [x] All 29 backend tests pass inside container

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)