### PR TITLE
feat: add WebP, BMP, and GIF image format support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,11 +26,11 @@ logger = logging.getLogger(__name__)
 
 # Configuration constants
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
-ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.PNG', '.JPG', '.JPEG'}
+ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'}
 CLEANUP_INTERVAL_SECONDS = 600   # Run cleanup every 10 minutes
 FILE_MAX_AGE_SECONDS = 3600      # Delete files older than 1 hour
 ERROR_CODES = {
-    'INVALID_FORMAT': 'File format is not supported. Only PNG and JPG/JPEG files are allowed.',
+    'INVALID_FORMAT': 'File format is not supported. Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF.',
     'FILE_TOO_LARGE': f'File size exceeds the maximum limit of {MAX_FILE_SIZE / (1024 * 1024):.0f}MB.',
     'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -76,6 +76,24 @@ class TestValidateFile:
         # JPEG is now supported
         validate_file("image.jpeg", 1024)
 
+    def test_valid_webp(self):
+        validate_file("image.webp", 1024)
+
+    def test_valid_bmp(self):
+        validate_file("image.bmp", 1024)
+
+    def test_valid_gif(self):
+        validate_file("image.gif", 1024)
+
+    def test_valid_webp_uppercase(self):
+        validate_file("IMAGE.WEBP", 1024)
+
+    def test_valid_bmp_uppercase(self):
+        validate_file("IMAGE.BMP", 1024)
+
+    def test_valid_gif_uppercase(self):
+        validate_file("IMAGE.GIF", 1024)
+
     def test_invalid_extension_txt(self):
         with pytest.raises(HTTPException) as exc_info:
             validate_file("image.txt", 1024)
@@ -338,6 +356,81 @@ async def test_upload_jpg_conversion_failure(mock_exists, mock_makedirs, mock_vt
     assert response.status_code == 500
     result = response.json()
     assert result["detail"]["code"] == "CONVERSION_FAILED"
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer):
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    webp_bytes = b'RIFF' + b'\x00' * 4 + b'WEBP' + b'\x00' * 40
+    b64 = base64.b64encode(webp_bytes).decode()
+    data_url = f"data:image/webp;base64,{b64}"
+
+    with patch("builtins.open", MagicMock()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "photo.webp", "data": data_url},
+            )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"] is True
+    assert result["filename"] == "photo.svg"
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer):
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    bmp_bytes = b'BM' + b'\x00' * 50
+    b64 = base64.b64encode(bmp_bytes).decode()
+    data_url = f"data:image/bmp;base64,{b64}"
+
+    with patch("builtins.open", MagicMock()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "photo.bmp", "data": data_url},
+            )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"] is True
+    assert result["filename"] == "photo.svg"
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_gif_success(mock_exists, mock_makedirs, mock_vtracer):
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    gif_bytes = b'GIF89a' + b'\x00' * 50
+    b64 = base64.b64encode(gif_bytes).decode()
+    data_url = f"data:image/gif;base64,{b64}"
+
+    with patch("builtins.open", MagicMock()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "animation.gif", "data": data_url},
+            )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"] is True
+    assert result["filename"] == "animation.svg"
 
 
 @pytest.mark.anyio

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -20,11 +20,12 @@
 
   function validateFile(file: File): string | null {
     // Check file extension
-    const validExtensions = ['.png', '.PNG', '.jpg', '.JPG', '.jpeg', '.JPEG'];
-    const hasValidExtension = validExtensions.some(ext => file.name.endsWith(ext));
+    const validExtensions = ['.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'];
+    const lowerName = file.name.toLowerCase();
+    const hasValidExtension = validExtensions.some(ext => lowerName.endsWith(ext));
 
     if (!hasValidExtension) {
-      return 'Only PNG and JPG/JPEG files are allowed';
+      return 'Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF';
     }
 
     // Check file size
@@ -94,7 +95,7 @@
       if (status.status === 'completed' && status.url) {
         const response = await fetch(status.url);
         const blob = await response.blob();
-        const svgFilename = filename.replace(/\.(png|jpg|jpeg)$/i, '.svg');
+        const svgFilename = filename.replace(/\.(png|jpg|jpeg|webp|bmp|gif)$/i, '.svg');
         zip.file(svgFilename, blob);
       }
     }
@@ -117,7 +118,7 @@
       <img src={pngIcon} class="icon" alt="Image icon" />
     </svelte:fragment>
 	  <svelte:fragment slot="message">Upload a file or drag and drop</svelte:fragment>
-	  <svelte:fragment slot="meta">PNG and JPG/JPEG files are supported</svelte:fragment>
+	  <svelte:fragment slot="meta">PNG, JPG/JPEG, WebP, BMP, GIF files are supported</svelte:fragment>
   </FileDropzone>
 
   <div class="buttons">


### PR DESCRIPTION
## Summary
- Add WebP, BMP, and GIF to supported image formats in backend and frontend
- Simplify extension validation to use case-insensitive comparison (lowercase set + `.lower()`)
- Update UI text to list all supported formats
- Update download ZIP filename regex to handle new extensions

## Test plan
- [x] All 43 tests pass (added 9 new: 6 unit + 3 integration)
- [x] New unit tests: `test_valid_webp`, `test_valid_bmp`, `test_valid_gif`, plus uppercase variants
- [x] New integration tests: `test_upload_webp_success`, `test_upload_bmp_success`, `test_upload_gif_success`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)