### PR TITLE
feat: add VTracer conversion presets UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -162,12 +162,53 @@ def validate_file(filename: str, file_size: int) -> None:
             detail={'error': ERROR_CODES['FILE_TOO_LARGE'], 'code': 'FILE_TOO_LARGE'}
         )
 
-def image_to_svg(path: str) -> str:
+PRESETS = {
+    'high_quality': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 2,
+        'color_precision': 8,
+        'layer_difference': 8,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 20,
+        'splice_threshold': 45,
+        'path_precision': 5,
+    },
+    'balanced': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 4,
+        'color_precision': 6,
+        'layer_difference': 16,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 10,
+        'splice_threshold': 45,
+        'path_precision': 3,
+    },
+    'fast': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 8,
+        'color_precision': 4,
+        'layer_difference': 32,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 5,
+        'splice_threshold': 45,
+        'path_precision': 2,
+    },
+}
+
+
+def image_to_svg(path: str, preset: str = 'balanced') -> str:
     """
-    Convert image (PNG/JPG) to SVG using vtracer for true vectorization.
+    Convert image to SVG using vtracer for true vectorization.
 
     Args:
         path: Path to the image file to convert
+        preset: Conversion preset ('high_quality', 'balanced', 'fast')
 
     Returns:
         Path to the converted SVG file
@@ -176,22 +217,14 @@ def image_to_svg(path: str) -> str:
         HTTPException: If conversion fails
     """
     output_path = str(Path(path).with_suffix('.svg'))
+    params = PRESETS.get(preset, PRESETS['balanced'])
 
     try:
-        logger.info(f"Starting conversion: {path}")
+        logger.info(f"Starting conversion: {path} (preset: {preset})")
         vtracer.convert_image_to_svg_py(
             path,
             output_path,
-            colormode='color',
-            mode='spline',
-            filter_speckle=4,
-            color_precision=6,
-            layer_difference=16,
-            corner_threshold=60,
-            length_threshold=4.0,
-            max_iterations=10,
-            splice_threshold=45,
-            path_precision=3
+            **params
         )
         logger.info(f"Successfully converted: {path} -> {output_path}")
         return output_path
@@ -209,6 +242,15 @@ def image_to_svg(path: str) -> str:
 async def health_check() -> JSONResponse:
     """Health check endpoint."""
     return JSONResponse({'status': 'healthy'})
+
+
+@app.get('/backend/presets')
+async def get_presets() -> JSONResponse:
+    """Return available conversion presets."""
+    return JSONResponse({
+        'presets': list(PRESETS.keys()),
+        'default': 'balanced',
+    })
 
 
 @app.post('/backend/upload/{request_id}')
@@ -246,7 +288,10 @@ async def image_processing(request_id: str, data: Dict):
         logger.info(f"Saved uploaded file: {file_path}")
 
         # Convert to SVG
-        output_path = image_to_svg(file_path)
+        preset = data.get('preset', 'balanced')
+        if preset not in PRESETS:
+            preset = 'balanced'
+        output_path = image_to_svg(file_path, preset=preset)
 
         svg_filename = Path(output_path).name
         response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -9,6 +9,7 @@ from main import (
     validate_file,
     _validate_uuid,
     sanitize_filename,
+    PRESETS,
 )
 
 
@@ -431,6 +432,91 @@ async def test_upload_gif_success(mock_exists, mock_makedirs, mock_vtracer):
     result = response.json()
     assert result["success"] is True
     assert result["filename"] == "animation.svg"
+
+
+class TestPresets:
+    def test_presets_exist(self):
+        assert 'high_quality' in PRESETS
+        assert 'balanced' in PRESETS
+        assert 'fast' in PRESETS
+
+    def test_preset_keys(self):
+        for preset_name, params in PRESETS.items():
+            assert 'colormode' in params
+            assert 'filter_speckle' in params
+            assert 'color_precision' in params
+
+    def test_high_quality_more_precise(self):
+        assert PRESETS['high_quality']['color_precision'] > PRESETS['balanced']['color_precision']
+        assert PRESETS['high_quality']['max_iterations'] > PRESETS['balanced']['max_iterations']
+
+    def test_fast_less_precise(self):
+        assert PRESETS['fast']['color_precision'] < PRESETS['balanced']['color_precision']
+        assert PRESETS['fast']['max_iterations'] < PRESETS['balanced']['max_iterations']
+
+
+@pytest.mark.anyio
+async def test_get_presets():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/backend/presets")
+    assert response.status_code == 200
+    result = response.json()
+    assert 'presets' in result
+    assert 'balanced' in result['presets']
+    assert result['default'] == 'balanced'
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer):
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
+    b64 = base64.b64encode(png_bytes).decode()
+    data_url = f"data:image/png;base64,{b64}"
+
+    with patch("builtins.open", MagicMock()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "test.png", "data": data_url, "preset": "high_quality"},
+            )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["success"] is True
+    # Verify vtracer was called with high_quality params
+    call_kwargs = mock_vtracer.convert_image_to_svg_py.call_args
+    assert call_kwargs[1]['color_precision'] == 8
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_with_invalid_preset_falls_back(mock_exists, mock_makedirs, mock_vtracer):
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
+    b64 = base64.b64encode(png_bytes).decode()
+    data_url = f"data:image/png;base64,{b64}"
+
+    with patch("builtins.open", MagicMock()):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "test.png", "data": data_url, "preset": "nonexistent"},
+            )
+
+    assert response.status_code == 200
+    # Should fall back to balanced
+    call_kwargs = mock_vtracer.convert_image_to_svg_py.call_args
+    assert call_kwargs[1]['color_precision'] == 6
 
 
 @pytest.mark.anyio

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -26,7 +26,7 @@ const getBase64 = (data: File): Promise<string> => {
   });
 }
 
-const doPost = async (url: string, data: File): Promise<ApiResponse> => {
+const doPost = async (url: string, data: File, preset: string = 'balanced'): Promise<ApiResponse> => {
   const name = data.name;
   const base64 = await getBase64(data);
   const response = await fetch(url, {
@@ -34,7 +34,7 @@ const doPost = async (url: string, data: File): Promise<ApiResponse> => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ name : name, data : base64 }),
+    body: JSON.stringify({ name : name, data : base64, preset }),
   });
 
   const result = await response.json();
@@ -51,10 +51,10 @@ const doPost = async (url: string, data: File): Promise<ApiResponse> => {
   return result as ApiResponse;
 }
 
-export const Post = async (data: File): Promise<ApiResponse> => {
+export const Post = async (data: File, preset: string = 'balanced'): Promise<ApiResponse> => {
   try {
     const url = baseURL();
-    const response = await doPost(url, data);
+    const response = await doPost(url, data, preset);
     return response;
   } catch (error: unknown) {
     const apiError = error as ApiError;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 
   let files: FileList;
   let fileStatuses: {[key: string]: FileStatus} = {};
+  let selectedPreset: string = 'balanced';
 
   const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -67,7 +68,7 @@
       fileStatuses[file.name] = { status: 'processing' };
 
       try {
-        const data = await Post(file);
+        const data = await Post(file, selectedPreset);
 
         if (data.success) {
           fileStatuses[file.name] = {
@@ -120,6 +121,15 @@
 	  <svelte:fragment slot="message">Upload a file or drag and drop</svelte:fragment>
 	  <svelte:fragment slot="meta">PNG, JPG/JPEG, WebP, BMP, GIF files are supported</svelte:fragment>
   </FileDropzone>
+
+  <div class="preset-selector">
+    <label for="preset">Quality Preset:</label>
+    <select id="preset" bind:value={selectedPreset} class="select">
+      <option value="high_quality">High Quality</option>
+      <option value="balanced">Balanced</option>
+      <option value="fast">Fast</option>
+    </select>
+  </div>
 
   <div class="buttons">
     <button type="button" class="btn variant-filled send" on:click={send} disabled={!files || files.length === 0}>
@@ -216,10 +226,30 @@
     margin: 0 auto;
   }
 
+  .preset-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .preset-selector label {
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+
+  .preset-selector select {
+    padding: 0.4rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    font-size: 0.9rem;
+    background: var(--color-surface-200, #f3f4f6);
+  }
+
   .buttons {
     display: flex;
     width: 50%;
-    margin-top: 2rem;
+    margin-top: 1rem;
   }
 
   button {


### PR DESCRIPTION
## Summary
- Add quality preset selector to the UI: **High Quality**, **Balanced** (default), **Fast**
- Backend accepts optional `preset` parameter in upload request body
- Add `GET /backend/presets` endpoint listing available presets
- Invalid preset values fall back to Balanced
- Presets control: color_precision, filter_speckle, max_iterations, path_precision, layer_difference

## Test plan
- [x] All 50 tests pass (added 7 new: 4 unit + 3 integration)
- [x] Preset selector renders in UI
- [x] High Quality preset sends correct params to VTracer
- [x] Invalid preset falls back to Balanced

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)