### PR TITLE
perf: optimize batch processing with concurrent uploads

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -287,11 +287,11 @@ async def image_processing(request_id: str, data: Dict):
             f.write(decoded_img)
         logger.info(f"Saved uploaded file: {file_path}")
 
-        # Convert to SVG
+        # Convert to SVG (run in thread pool to avoid blocking event loop)
         preset = data.get('preset', 'balanced')
         if preset not in PRESETS:
             preset = 'balanced'
-        output_path = image_to_svg(file_path, preset=preset)
+        output_path = await asyncio.to_thread(image_to_svg, file_path, preset)
 
         svg_filename = Path(output_path).name
         response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -37,12 +37,40 @@
     return null;
   }
 
+  async function processFile(file: File) {
+    fileStatuses[file.name] = { status: 'processing' };
+    fileStatuses = fileStatuses;
+
+    try {
+      const data = await Post(file, selectedPreset);
+
+      if (data.success) {
+        fileStatuses[file.name] = {
+          status: 'completed',
+          url: data.url
+        };
+      } else {
+        fileStatuses[file.name] = {
+          status: 'failed',
+          error: data.error || 'Conversion failed'
+        };
+      }
+    } catch (error: any) {
+      fileStatuses[file.name] = {
+        status: 'failed',
+        error: error.detail?.error || error.message || 'An unexpected error occurred'
+      };
+    }
+    fileStatuses = fileStatuses;
+  }
+
   async function send() {
-    // Initialize all files as pending
+    const validFiles: File[] = [];
+
+    // Validate all files first
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
 
-      // Validate file
       const validationError = validateFile(file);
       if (validationError) {
         fileStatuses[file.name] = {
@@ -53,41 +81,12 @@
       }
 
       fileStatuses[file.name] = { status: 'pending' };
+      validFiles.push(file);
     }
+    fileStatuses = fileStatuses;
 
-    // Process each file
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-
-      // Skip if validation failed
-      if (fileStatuses[file.name].status === 'failed') {
-        continue;
-      }
-
-      // Update status to processing
-      fileStatuses[file.name] = { status: 'processing' };
-
-      try {
-        const data = await Post(file, selectedPreset);
-
-        if (data.success) {
-          fileStatuses[file.name] = {
-            status: 'completed',
-            url: data.url
-          };
-        } else {
-          fileStatuses[file.name] = {
-            status: 'failed',
-            error: data.error || 'Conversion failed'
-          };
-        }
-      } catch (error: any) {
-        fileStatuses[file.name] = {
-          status: 'failed',
-          error: error.detail?.error || error.message || 'An unexpected error occurred'
-        };
-      }
-    }
+    // Process all valid files concurrently
+    await Promise.all(validFiles.map(file => processFile(file)));
   }
 
   async function download() {


### PR DESCRIPTION
## Summary
- **Backend**: Use `asyncio.to_thread()` for vtracer conversion to avoid blocking the event loop, enabling true concurrent request handling
- **Frontend**: Replace sequential file processing with `Promise.all()` for parallel uploads

## Changes
- `backend/main.py`: Wrap `image_to_svg()` call with `asyncio.to_thread()`
- `frontend/+page.svelte`: Extract `processFile()` function, use `Promise.all()` in `send()`

## Test plan
- [x] All 50 backend tests pass
- [x] Concurrent uploads work correctly with reactive status updates

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)