### PR TITLE
fix: add anyio to dev deps and backend/static to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### Project ###
+backend/static/
+
 ### ArchLinuxPackages ###
 *.tar
 *.tar.*

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest==7.4.3
+anyio==3.7.1
 httpx==0.25.2


### PR DESCRIPTION
## Summary
- Add `anyio==3.7.1` to `requirements-dev.txt` (explicit dependency for `@pytest.mark.anyio`)
- Add `backend/static/` to `.gitignore` (runtime-generated directory)

## Test plan
- [x] All 50 backend tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)