### PR TITLE
ci: add frontend checks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,28 @@ jobs:
 
       - name: Run tests
         run: python -m pytest tests/ -v
+
+  frontend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run check
+
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
## Summary
- Add `frontend-test` job to GitHub Actions CI workflow
- Runs `svelte-check` (type checking) and `vitest` (unit tests)
- Uses Node.js 20 with npm caching

## Test plan
- [x] CI workflow syntax is valid
- [ ] CI pipeline runs both backend and frontend jobs on PR

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)