### PR TITLE
chore: add unified test script and document sample.env

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Running Backend Tests ==="
+cd backend
+pip install -r requirements-dev.txt -q
+python -m pytest tests/ -v
+cd ..
+
+echo ""
+echo "=== Running Frontend Tests ==="
+cd frontend
+npm ci --silent
+npm run test
+
+echo ""
+echo "=== All tests passed ==="

--- a/sample.env
+++ b/sample.env
@@ -1,5 +1,19 @@
-# Environment variables for docker-compose
-IP=0.0.0.0
-FRONTEND_PORT=55030
-BACKEND_PORT=55031
+# ============================================
+# Image to SVG Converter - Environment Config
+# ============================================
+# Copy this file to .env before starting:
+#   mv sample.env .env
 
+# Server IP address
+# Use 0.0.0.0 to listen on all interfaces, or a specific IP for restricted access
+# Find your IP with: ip a (Linux) or ifconfig (macOS)
+IP=0.0.0.0
+
+# Frontend port (SvelteKit dev server)
+# Access the web UI at http://{IP}:{FRONTEND_PORT}
+FRONTEND_PORT=55030
+
+# Backend port (FastAPI server)
+# API available at http://{IP}:{BACKEND_PORT}/backend/
+# Swagger docs at http://{IP}:{BACKEND_PORT}/api/docs
+BACKEND_PORT=55031


### PR DESCRIPTION
## Summary
- Add `run_tests.sh` script to run backend (pytest) and frontend (vitest) tests sequentially
- Add descriptive comments to `sample.env` explaining each variable, defaults, and usage

## Test plan
- [x] `run_tests.sh` is executable
- [ ] CI passes

Closes #54, Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)