### PR TITLE
feat: add SSE progress streaming for conversion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from typing import Dict
@@ -35,6 +35,9 @@ ERROR_CODES = {
     'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
 }
+
+# Progress tracking for SSE
+progress_store: Dict[str, dict] = {}
 
 # Load environment variables
 load_dotenv()
@@ -253,6 +256,39 @@ async def get_presets() -> JSONResponse:
     })
 
 
+def _update_progress(request_id: str, stage: str, progress: int) -> None:
+    """Update progress for a request."""
+    progress_store[request_id] = {'stage': stage, 'progress': progress}
+
+
+@app.get('/backend/progress/{request_id}')
+async def stream_progress(request_id: str):
+    """SSE endpoint to stream conversion progress for a request."""
+    if not _validate_uuid(request_id):
+        raise HTTPException(
+            status_code=400,
+            detail={'error': 'Invalid request_id', 'code': 'INVALID_UUID'}
+        )
+
+    async def event_generator():
+        import json
+        last_stage = None
+        while True:
+            entry = progress_store.get(request_id)
+            if entry and entry['stage'] != last_stage:
+                last_stage = entry['stage']
+                yield f"data: {json.dumps(entry)}\n\n"
+                if entry['stage'] in ('completed', 'failed'):
+                    break
+            await asyncio.sleep(0.2)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type='text/event-stream',
+        headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'}
+    )
+
+
 @app.post('/backend/upload/{request_id}')
 async def image_processing(request_id: str, data: Dict):
     """
@@ -272,11 +308,15 @@ async def image_processing(request_id: str, data: Dict):
                 detail={'error': ERROR_CODES['MISSING_DATA'], 'code': 'MISSING_DATA'}
             )
 
+        _update_progress(request_id, 'decoding', 10)
+
         name = sanitize_filename(data['name'])
         img_data = data['data'].split(',')[1]
         decoded_img = base64.b64decode(img_data)
 
         validate_file(name, len(decoded_img))
+
+        _update_progress(request_id, 'saving', 25)
 
         request_dir = f'static/{request_id}'
         if not os.path.exists(request_dir):
@@ -287,6 +327,8 @@ async def image_processing(request_id: str, data: Dict):
             f.write(decoded_img)
         logger.info(f"Saved uploaded file: {file_path}")
 
+        _update_progress(request_id, 'converting', 50)
+
         # Convert to SVG (run in thread pool to avoid blocking event loop)
         preset = data.get('preset', 'balanced')
         if preset not in PRESETS:
@@ -296,6 +338,8 @@ async def image_processing(request_id: str, data: Dict):
         svg_filename = Path(output_path).name
         response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'
 
+        _update_progress(request_id, 'completed', 100)
+
         logger.info(f"Request {request_id} completed successfully")
         return JSONResponse({
             'success': True,
@@ -304,8 +348,10 @@ async def image_processing(request_id: str, data: Dict):
         })
 
     except HTTPException:
+        _update_progress(request_id, 'failed', 0)
         raise
     except Exception as e:
+        _update_progress(request_id, 'failed', 0)
         logger.error(f"Unexpected error in request {request_id}: {str(e)}", exc_info=True)
         raise HTTPException(
             status_code=500,

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -10,11 +10,21 @@ interface ApiError {
   detail: { error: string; code?: string } | Record<string, unknown>;
 }
 
-const baseURL = (): string => {
+export interface ProgressEvent {
+  stage: string;
+  progress: number;
+}
+
+const getBackendBase = () => {
   const HOST = import.meta.env.VITE_HOST;
   const backendPORT = import.meta.env.VITE_BACKEND_PORT;
+  return `http://${HOST}:${backendPORT}`;
+}
+
+const baseURL = (): { url: string; id: string } => {
+  const base = getBackendBase();
   const ID = crypto.randomUUID();
-  return `http://${HOST}:${backendPORT}/backend/upload/${ID}`;
+  return { url: `${base}/backend/upload/${ID}`, id: ID };
 }
 
 const getBase64 = (data: File): Promise<string> => {
@@ -51,10 +61,36 @@ const doPost = async (url: string, data: File, preset: string = 'balanced'): Pro
   return result as ApiResponse;
 }
 
-export const Post = async (data: File, preset: string = 'balanced'): Promise<ApiResponse> => {
+export const Post = async (
+  data: File,
+  preset: string = 'balanced',
+  onProgress?: (event: ProgressEvent) => void
+): Promise<ApiResponse> => {
   try {
-    const url = baseURL();
+    const { url, id } = baseURL();
+
+    // Start SSE progress listener if callback provided
+    let eventSource: EventSource | null = null;
+    if (onProgress) {
+      const progressUrl = `${getBackendBase()}/backend/progress/${id}`;
+      eventSource = new EventSource(progressUrl);
+      eventSource.onmessage = (e) => {
+        try {
+          const progress = JSON.parse(e.data) as ProgressEvent;
+          onProgress(progress);
+        } catch {
+          // ignore parse errors
+        }
+      };
+      eventSource.onerror = () => {
+        eventSource?.close();
+        eventSource = null;
+      };
+    }
+
     const response = await doPost(url, data, preset);
+
+    eventSource?.close();
     return response;
   } catch (error: unknown) {
     const apiError = error as ApiError;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
   import JSZip from 'jszip';
   import pngIcon from '$lib/assets/png-icon.png';
-  import { Post } from '$lib/post';
+  import { Post, type ProgressEvent } from '$lib/post';
   import { saveAs } from 'file-saver';
 
   type ConversionStatus = 'pending' | 'processing' | 'completed' | 'failed';
@@ -10,6 +10,8 @@
     url?: string;
     status: ConversionStatus;
     error?: string;
+    stage?: string;
+    progress?: number;
   }
 
   let files: FileList | undefined = $state(undefined);
@@ -39,10 +41,18 @@
   }
 
   async function processFile(file: File) {
-    fileStatuses[file.name] = { status: 'processing' };
+    fileStatuses[file.name] = { status: 'processing', stage: 'uploading', progress: 0 };
 
     try {
-      const data = await Post(file, selectedPreset);
+      const data = await Post(file, selectedPreset, (evt: ProgressEvent) => {
+        if (fileStatuses[file.name]?.status === 'processing') {
+          fileStatuses[file.name] = {
+            ...fileStatuses[file.name],
+            stage: evt.stage,
+            progress: evt.progress
+          };
+        }
+      });
 
       if (data.success) {
         fileStatuses[file.name] = {
@@ -201,7 +211,24 @@
                 {:else if fileStatuses[file.name].status === 'processing'}
                   <div class="processing">
                     <div class="spinner"></div>
-                    <span>Processing...</span>
+                    <span class="stage-label">
+                      {#if fileStatuses[file.name].stage === 'uploading'}
+                        Uploading...
+                      {:else if fileStatuses[file.name].stage === 'decoding'}
+                        Decoding...
+                      {:else if fileStatuses[file.name].stage === 'saving'}
+                        Saving...
+                      {:else if fileStatuses[file.name].stage === 'converting'}
+                        Converting...
+                      {:else}
+                        Processing...
+                      {/if}
+                    </span>
+                    {#if fileStatuses[file.name].progress != null}
+                      <div class="progress-bar">
+                        <div class="progress-fill" style="width: {fileStatuses[file.name].progress}%"></div>
+                      </div>
+                    {/if}
                   </div>
                 {:else if fileStatuses[file.name].status === 'completed'}
                   <span class="badge badge-success">&#x2713; Completed</span>
@@ -407,6 +434,26 @@
 
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  .stage-label {
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+
+  .progress-bar {
+    width: 80%;
+    height: 6px;
+    background: #e5e7eb;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: #3b82f6;
+    border-radius: 3px;
+    transition: width 0.3s ease;
   }
 
   .error-status {


### PR DESCRIPTION
## Summary
- Add `GET /backend/progress/{request_id}` SSE endpoint for real-time conversion progress
- Backend reports stages: decoding (10%), saving (25%), converting (50%), completed (100%)
- Frontend shows progress bar and stage labels during file conversion
- Falls back gracefully if SSE connection fails

## Test plan
- [x] Backend tests pass (50/50)
- [x] Frontend type check passes (0 errors)
- [x] Frontend tests pass (20/20)
- [x] Build succeeds
- [ ] Manual test: progress bar updates during conversion

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)