### PR TITLE
refactor: restrict CORS, improve error handling, extract validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -119,8 +119,8 @@ app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=True,
-        allow_methods=['*'],
-        allow_headers=['*'],
+        allow_methods=['GET', 'POST'],
+        allow_headers=['Content-Type'],
         )
 
 

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -4,10 +4,16 @@ interface ApiResponse {
   filename: string;
 }
 
-interface ApiError {
+export class ApiError extends Error {
   status: number;
-  message: string;
   detail: { error: string; code?: string } | Record<string, unknown>;
+
+  constructor(message: string, status: number, detail: Record<string, unknown>) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.detail = detail;
+  }
 }
 
 export interface ProgressEvent {
@@ -49,13 +55,12 @@ const doPost = async (url: string, data: File, preset: string = 'balanced'): Pro
 
   const result = await response.json();
 
-  // Check if the response indicates an error
   if (!response.ok) {
-    throw {
-      status: response.status,
-      message: response.statusText,
-      detail: result.detail || result
-    } as ApiError;
+    throw new ApiError(
+      response.statusText,
+      response.status,
+      result.detail || result
+    );
   }
 
   return result as ApiResponse;
@@ -91,11 +96,11 @@ export const Post = async (
     const response = await doPost(url, data, preset);
     return response;
   } catch (error: unknown) {
-    const apiError = error as ApiError;
-    throw {
-      message: apiError.message || 'Network error',
-      detail: apiError.detail || { error: 'Failed to connect to server' }
-    };
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : 'Network error';
+    throw new ApiError(message, 0, { error: 'Failed to connect to server' });
   } finally {
     eventSource?.close();
   }

--- a/frontend/src/lib/validate.ts
+++ b/frontend/src/lib/validate.ts
@@ -1,0 +1,17 @@
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+export const VALID_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'];
+
+export function validateFile(file: File): string | null {
+  const lowerName = file.name.toLowerCase();
+  const hasValidExtension = VALID_EXTENSIONS.some(ext => lowerName.endsWith(ext));
+
+  if (!hasValidExtension) {
+    return 'Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF';
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return `File size exceeds ${MAX_FILE_SIZE / (1024 * 1024)}MB limit`;
+  }
+
+  return null;
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang='ts'>
   import JSZip from 'jszip';
   import pngIcon from '$lib/assets/png-icon.png';
-  import { Post, type ProgressEvent } from '$lib/post';
+  import { Post, ApiError, type ProgressEvent } from '$lib/post';
+  import { validateFile } from '$lib/validate';
   import { saveAs } from 'file-saver';
 
   type ConversionStatus = 'pending' | 'processing' | 'completed' | 'failed';
@@ -37,26 +38,8 @@
     revokePreviewUrls();
   });
 
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-
   let completedCount = $derived(Object.values(fileStatuses).filter(s => s.status === 'completed').length);
   let hasCompleted = $derived(completedCount > 0);
-
-  function validateFile(file: File): string | null {
-    const validExtensions = ['.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'];
-    const lowerName = file.name.toLowerCase();
-    const hasValidExtension = validExtensions.some(ext => lowerName.endsWith(ext));
-
-    if (!hasValidExtension) {
-      return 'Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF';
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      return `File size exceeds ${MAX_FILE_SIZE / (1024 * 1024)}MB limit`;
-    }
-
-    return null;
-  }
 
   async function processFile(file: File) {
     fileStatuses[file.name] = { status: 'processing', stage: 'uploading', progress: 0 };
@@ -83,10 +66,13 @@
           error: 'Conversion failed'
         };
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof ApiError
+        ? (error.detail as { error?: string })?.error || error.message
+        : error instanceof Error ? error.message : 'An unexpected error occurred';
       fileStatuses[file.name] = {
         status: 'failed',
-        error: error.detail?.error || error.message || 'An unexpected error occurred'
+        error: message
       };
     }
   }

--- a/frontend/src/tests/post.test.ts
+++ b/frontend/src/tests/post.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Post } from '$lib/post';
+import { Post, ApiError } from '$lib/post';
 
 // Mock crypto.randomUUID
 vi.stubGlobal('crypto', {
@@ -36,7 +36,7 @@ describe('Post', () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
-  it('should throw on HTTP error response', async () => {
+  it('should throw ApiError on HTTP error response', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
@@ -46,19 +46,23 @@ describe('Post', () => {
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });
 
+    await expect(Post(file, 'balanced')).rejects.toBeInstanceOf(ApiError);
     await expect(Post(file, 'balanced')).rejects.toMatchObject({
       message: 'Bad Request',
+      status: 400,
       detail: { error: 'Invalid file' }
     });
   });
 
-  it('should throw network error when fetch fails', async () => {
+  it('should throw ApiError with network error when fetch fails', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
     const file = new File(['test'], 'test.png', { type: 'image/png' });
 
+    await expect(Post(file, 'balanced')).rejects.toBeInstanceOf(ApiError);
     await expect(Post(file, 'balanced')).rejects.toMatchObject({
-      message: 'Network error'
+      message: 'Network error',
+      status: 0
     });
   });
 

--- a/frontend/src/tests/validation.test.ts
+++ b/frontend/src/tests/validation.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from 'vitest';
-
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-
-function validateFile(file: File): string | null {
-  const validExtensions = ['.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'];
-  const lowerName = file.name.toLowerCase();
-  const hasValidExtension = validExtensions.some(ext => lowerName.endsWith(ext));
-
-  if (!hasValidExtension) {
-    return 'Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF';
-  }
-
-  if (file.size > MAX_FILE_SIZE) {
-    return `File size exceeds ${MAX_FILE_SIZE / (1024 * 1024)}MB limit`;
-  }
-
-  return null;
-}
+import { validateFile } from '$lib/validate';
 
 describe('validateFile', () => {
   it('should accept PNG files', () => {


### PR DESCRIPTION
## Summary
- Restrict CORS to GET/POST methods and Content-Type header (was wildcard)
- Replace plain error objects with `ApiError` class extending `Error` in post.ts
- Extract file validation to `$lib/validate.ts` shared module (removes duplication)
- Fix `error: any` → `error: unknown` type safety in +page.svelte

## Test plan
- [x] Backend tests pass (55/55)
- [x] Frontend type check passes (0 errors)
- [x] Frontend tests pass (20/20)

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)