### PR TITLE
chore: add CI pip cache, frontend .env.example, update copyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: backend/requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Frontend environment variables
+# These are set automatically by Docker Compose via compose.yml
+# Only needed for local development without Docker
+
+VITE_HOST=localhost
+VITE_BACKEND_PORT=55031

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -266,7 +266,7 @@
   {/if}
 
   <div class="footer">
-    <p>&copy; 2023 <a href="https://hirawatasou.com" target="_blank">So Hirawata</a></p>
+    <p>&copy; 2024 <a href="https://hirawatasou.com" target="_blank">So Hirawata</a></p>
   </div>
 
 </section>


### PR DESCRIPTION
## Summary
- Add pip dependency caching to CI backend job for faster builds
- Create `frontend/.env.example` documenting required env vars for local dev
- Update copyright year from 2023 to 2024

## Test plan
- [ ] CI passes (with pip cache working)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)