### PR TITLE
Fix unhandled errors in base64 data URL parsing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -329,8 +329,22 @@ async def image_processing(request_id: str, data: Dict):
         _update_progress(request_id, 'decoding', 10)
 
         name = sanitize_filename(data['name'])
-        img_data = data['data'].split(',')[1]
-        decoded_img = base64.b64decode(img_data)
+
+        try:
+            img_data = data['data'].split(',')[1]
+        except IndexError:
+            raise HTTPException(
+                status_code=400,
+                detail={'error': 'Malformed data URL: missing base64 content.', 'code': 'MALFORMED_DATA_URL'}
+            )
+
+        try:
+            decoded_img = base64.b64decode(img_data)
+        except Exception:
+            raise HTTPException(
+                status_code=400,
+                detail={'error': 'Invalid base64 data.', 'code': 'INVALID_BASE64'}
+            )
 
         validate_file(name, len(decoded_img))
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -600,3 +600,32 @@ class TestUpdateProgress:
         _update_progress(request_id, 'saving', 25)
         assert progress_store[request_id] == {'stage': 'saving', 'progress': 25}
         progress_store.pop(request_id, None)
+
+
+# --- Data URL parsing error tests ---
+
+
+@pytest.mark.anyio
+async def test_upload_malformed_data_url_no_comma():
+    """Data URL without comma should return 400 with MALFORMED_DATA_URL code."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+            json={"name": "test.png", "data": "data:image/png;base64"},
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "MALFORMED_DATA_URL"
+
+
+@pytest.mark.anyio
+async def test_upload_invalid_base64_data():
+    """Invalid base64 content should return 400 with INVALID_BASE64 code."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+            json={"name": "test.png", "data": "data:image/png;base64,!!!not-valid-base64!!!"},
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INVALID_BASE64"


### PR DESCRIPTION
## Summary
- Add explicit error handling for malformed data URLs (missing comma → `IndexError`) returning 400 with `MALFORMED_DATA_URL` code
- Add explicit error handling for invalid base64 content (`binascii.Error`) returning 400 with `INVALID_BASE64` code
- Add 2 integration tests covering both error scenarios (57 total backend tests)

## Test plan
- [x] `test_upload_malformed_data_url_no_comma` - verifies 400 response for data URL without comma
- [x] `test_upload_invalid_base64_data` - verifies 400 response for corrupted base64
- [x] All 57 backend tests pass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)