### PR TITLE
Add API rate limiting with SlowAPI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,10 +12,13 @@ from pathlib import Path
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 from typing import Dict
 
 # Configure logging
@@ -38,6 +41,10 @@ ERROR_CODES = {
     'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
 }
+
+# Rate limiting
+UPLOAD_RATE_LIMIT = "10/minute"
+limiter = Limiter(key_func=get_remote_address)
 
 # Progress tracking for SSE
 progress_store: Dict[str, dict] = {}
@@ -107,6 +114,8 @@ async def lifespan(app: FastAPI):
 
 # Create FastAPI instance
 app = FastAPI(docs_url='/api/docs', lifespan=lifespan)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Origin for CORS
 origins = [
@@ -308,7 +317,8 @@ async def stream_progress(request_id: str):
 
 
 @app.post('/backend/upload/{request_id}')
-async def image_processing(request_id: str, data: Dict):
+@limiter.limit(UPLOAD_RATE_LIMIT)
+async def image_processing(request: Request, request_id: str, data: Dict):
     """
     Process uploaded PNG file and convert to SVG.
     """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.103.2
 python-dotenv==1.0.0
+slowapi==0.1.9
 uvicorn==0.23.2
 vtracer==0.6.11

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -12,6 +12,8 @@ from main import (
     PRESETS,
     progress_store,
     _update_progress,
+    limiter,
+    UPLOAD_RATE_LIMIT,
 )
 
 
@@ -128,6 +130,13 @@ class TestValidateFile:
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Reset rate limiter state before each test."""
+    limiter.reset()
+    yield
 
 
 @pytest.mark.anyio
@@ -629,3 +638,40 @@ async def test_upload_invalid_base64_data():
         )
     assert response.status_code == 400
     assert response.json()["detail"]["code"] == "INVALID_BASE64"
+
+
+# --- Rate limiting tests ---
+
+
+def test_upload_rate_limit_constant():
+    """Verify the rate limit is configured."""
+    assert UPLOAD_RATE_LIMIT == "10/minute"
+
+
+@pytest.mark.anyio
+async def test_upload_rate_limit_exceeded():
+    """Exceeding the upload rate limit should return 429."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Send 11 requests (limit is 10/minute) - use invalid UUID to fail fast
+        for _ in range(10):
+            await client.post(
+                "/backend/upload/not-a-uuid",
+                json={"name": "test.png", "data": "x"},
+            )
+        # 11th request should be rate limited
+        response = await client.post(
+            "/backend/upload/not-a-uuid",
+            json={"name": "test.png", "data": "x"},
+        )
+    assert response.status_code == 429
+
+
+@pytest.mark.anyio
+async def test_health_not_rate_limited():
+    """Health endpoint should not be rate limited."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(15):
+            response = await client.get("/backend/health")
+            assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Add SlowAPI rate limiting to upload endpoint (10 requests/minute per IP)
- Health and preset endpoints remain unrestricted
- Add 3 new tests: rate limit constant, 429 on exceeded, health not limited (60 total)
- Add `slowapi==0.1.9` to requirements.txt

## Test plan
- [x] `test_upload_rate_limit_constant` - verifies configured rate
- [x] `test_upload_rate_limit_exceeded` - verifies 429 after 10 requests
- [x] `test_health_not_rate_limited` - verifies health endpoint is unrestricted
- [x] All 60 backend tests pass

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)