### PR TITLE
Add conversion metrics display (file size and time)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -371,12 +371,18 @@ async def image_processing(request: Request, request_id: str, data: Dict):
 
         _update_progress(request_id, 'converting', 50)
 
+        original_size = len(decoded_img)
+
         # Convert to SVG (run in thread pool to avoid blocking event loop)
         preset = data.get('preset', 'balanced')
         if preset not in PRESETS:
             preset = 'balanced'
-        output_path = await asyncio.to_thread(image_to_svg, file_path, preset)
 
+        convert_start = time.monotonic()
+        output_path = await asyncio.to_thread(image_to_svg, file_path, preset)
+        conversion_time_ms = round((time.monotonic() - convert_start) * 1000)
+
+        svg_size = os.path.getsize(output_path)
         svg_filename = Path(output_path).name
         response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'
 
@@ -386,7 +392,10 @@ async def image_processing(request: Request, request_id: str, data: Dict):
         return JSONResponse({
             'success': True,
             'url': response_url,
-            'filename': svg_filename
+            'filename': svg_filename,
+            'original_size': original_size,
+            'svg_size': svg_size,
+            'conversion_time_ms': conversion_time_ms,
         })
 
     except HTTPException:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -190,8 +190,9 @@ async def test_upload_invalid_format():
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.image_to_svg")
-async def test_upload_path_traversal(mock_image_to_svg):
+async def test_upload_path_traversal(mock_image_to_svg, mock_getsize):
     # Mock vtracer to avoid actual conversion
     mock_image_to_svg.return_value = "static/550e8400-e29b-41d4-a716-446655440000/passwd.svg"
 
@@ -212,10 +213,11 @@ async def test_upload_path_traversal(mock_image_to_svg):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
@@ -234,13 +236,17 @@ async def test_upload_success(mock_exists, mock_makedirs, mock_vtracer):
     result = response.json()
     assert result["success"] is True
     assert result["filename"] == "test.svg"
+    assert result["original_size"] == len(png_bytes)
+    assert result["svg_size"] == 2048
+    assert "conversion_time_ms" in result
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_jpg_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_jpg_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     # JFIF header for JPG
@@ -263,10 +269,11 @@ async def test_upload_jpg_success(mock_exists, mock_makedirs, mock_vtracer):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_jpeg_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_jpeg_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     jpg_bytes = b'\xff\xd8\xff\xe0' + b'\x00' * 50
@@ -288,10 +295,11 @@ async def test_upload_jpeg_success(mock_exists, mock_makedirs, mock_vtracer):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_jpg_uppercase_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_jpg_uppercase_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     jpg_bytes = b'\xff\xd8\xff\xe0' + b'\x00' * 50
@@ -313,8 +321,9 @@ async def test_upload_jpg_uppercase_success(mock_exists, mock_makedirs, mock_vtr
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.image_to_svg")
-async def test_upload_mixed_formats_sequentially(mock_image_to_svg):
+async def test_upload_mixed_formats_sequentially(mock_image_to_svg, mock_getsize):
     """Test uploading PNG, JPG, and JPEG files in sequence."""
     files = [
         ("test.png", "image/png", b'\x89PNG\r\n\x1a\n' + b'\x00' * 50),
@@ -371,10 +380,11 @@ async def test_upload_jpg_conversion_failure(mock_exists, mock_makedirs, mock_vt
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     webp_bytes = b'RIFF' + b'\x00' * 4 + b'WEBP' + b'\x00' * 40
@@ -396,10 +406,11 @@ async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     bmp_bytes = b'BM' + b'\x00' * 50
@@ -421,10 +432,11 @@ async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_gif_success(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_gif_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     gif_bytes = b'GIF89a' + b'\x00' * 50
@@ -479,10 +491,11 @@ async def test_get_presets():
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
@@ -506,10 +519,11 @@ async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer):
 
 
 @pytest.mark.anyio
+@patch("main.os.path.getsize", return_value=2048)
 @patch("main.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
-async def test_upload_with_invalid_preset_falls_back(mock_exists, mock_makedirs, mock_vtracer):
+async def test_upload_with_invalid_preset_falls_back(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
     mock_vtracer.convert_image_to_svg_py = MagicMock()
 
     png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -2,6 +2,9 @@ interface ApiResponse {
   success: boolean;
   url: string;
   filename: string;
+  original_size?: number;
+  svg_size?: number;
+  conversion_time_ms?: number;
 }
 
 export class ApiError extends Error {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -14,6 +14,15 @@
     stage?: string;
     progress?: number;
     displayName: string;
+    originalSize?: number;
+    svgSize?: number;
+    conversionTimeMs?: number;
+  }
+
+  function formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
   import { onDestroy } from 'svelte';
@@ -66,7 +75,10 @@
         fileStatuses[key] = {
           status: 'completed',
           url: data.url,
-          displayName: file.name
+          displayName: file.name,
+          originalSize: data.original_size,
+          svgSize: data.svg_size,
+          conversionTimeMs: data.conversion_time_ms,
         };
       } else {
         fileStatuses[key] = {
@@ -283,6 +295,12 @@
             <td>
               {#if fileStatuses[key]?.status === 'completed' && fileStatuses[key].url}
                 <img src={fileStatuses[key].url} alt="SVG output" class="preview-img" />
+                {#if fileStatuses[key].originalSize != null}
+                  <p class="metrics">
+                    {formatSize(fileStatuses[key].originalSize ?? 0)} → {formatSize(fileStatuses[key].svgSize ?? 0)}
+                    <br />{fileStatuses[key].conversionTimeMs}ms
+                  </p>
+                {/if}
               {:else if fileStatuses[key]?.status === 'processing'}
                 <p class="text-muted">Converting...</p>
               {:else if fileStatuses[key]?.status === 'failed'}
@@ -512,6 +530,13 @@
   .text-muted {
     color: #9ca3af;
     font-style: italic;
+  }
+
+  .metrics {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+    line-height: 1.4;
   }
 
   .badge {


### PR DESCRIPTION
## Summary
- Backend now returns `original_size`, `svg_size`, and `conversion_time_ms` in upload response
- Frontend displays metrics (size comparison and conversion time) below SVG preview
- Updated `ApiResponse` interface with optional metric fields
- Added `formatSize()` helper for human-readable file sizes (B/KB/MB)
- Updated all backend upload success tests to mock `os.path.getsize`

## Test plan
- [x] All 60 backend tests pass (metrics verified in `test_upload_success`)
- [x] All 20 frontend tests pass
- [x] svelte-check passes (0 errors)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)