### PR TITLE
Add preset tooltips and resolve a11y warning

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -194,7 +194,7 @@
     onkeydown={(e) => { if (e.key === 'Enter') document.getElementById('file-input')?.click(); }}
     onclick={() => document.getElementById('file-input')?.click()}
   >
-    <img src={pngIcon} class="icon" alt="Image icon" />
+    <img src={pngIcon} class="icon" alt="Upload icon" />
     <p class="dropzone-message">Upload a file or drag and drop</p>
     <p class="dropzone-meta">PNG, JPG/JPEG, WebP, BMP, GIF files are supported</p>
     <input
@@ -209,10 +209,10 @@
 
   <div class="preset-selector">
     <label for="preset">Quality Preset:</label>
-    <select id="preset" bind:value={selectedPreset} class="select">
-      <option value="high_quality">High Quality</option>
-      <option value="balanced">Balanced</option>
-      <option value="fast">Fast</option>
+    <select id="preset" bind:value={selectedPreset} class="select" title="Select conversion quality preset">
+      <option value="high_quality" title="Best detail, larger SVG, slower conversion">High Quality</option>
+      <option value="balanced" title="Good balance of detail, size, and speed">Balanced</option>
+      <option value="fast" title="Fastest conversion, smaller SVG, less detail">Fast</option>
     </select>
   </div>
 


### PR DESCRIPTION
## Summary
- Add `title` attributes to preset options describing quality trade-offs
- Fix `a11y_img_redundant_alt` warning by changing alt text from "Image icon" to "Upload icon"
- svelte-check now reports 0 errors, 0 warnings

## Test plan
- [x] svelte-check: 0 errors, 0 warnings (was 1 warning)
- [x] All 20 frontend tests pass

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)