### PR TITLE
Improve download endpoint security headers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -410,18 +410,26 @@ async def image_processing(request: Request, request_id: str, data: Dict):
         )
 
 
-@app.get('/backend/download/{request_id}', response_class=FileResponse)
+@app.get('/backend/download/{request_id}')
 async def get_image(request_id: str):
     if not _validate_uuid(request_id):
-        return JSONResponse({'error': 'Invalid request_id: must be a valid UUID format'}, status_code=400)
+        raise HTTPException(
+            status_code=400,
+            detail={'error': 'Invalid request_id: must be a valid UUID format', 'code': 'INVALID_UUID'}
+        )
     sanitized_id = sanitize_filename(request_id)
     request_dir = f'static/{sanitized_id}'
     if not os.path.exists(request_dir):
-        return JSONResponse({'error': 'Not found'}, status_code=404)
+        raise HTTPException(status_code=404, detail={'error': 'Not found', 'code': 'NOT_FOUND'})
     svg_path = glob.glob(f'{request_dir}/*.svg')
     if len(svg_path) == 0:
-        return JSONResponse({'error': 'Not found'}, status_code=404)
-    return FileResponse(svg_path[0])
+        raise HTTPException(status_code=404, detail={'error': 'Not found', 'code': 'NOT_FOUND'})
+    svg_filename = Path(svg_path[0]).name
+    return FileResponse(
+        svg_path[0],
+        media_type='image/svg+xml',
+        headers={'Content-Disposition': f'attachment; filename="{svg_filename}"'}
+    )
 
 
 if __name__ == '__main__':

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,4 @@
+import os
 import base64
 import pytest
 from unittest.mock import patch, MagicMock
@@ -550,6 +551,7 @@ async def test_download_invalid_uuid():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/backend/download/not-a-uuid")
     assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INVALID_UUID"
 
 
 @pytest.mark.anyio
@@ -560,6 +562,32 @@ async def test_download_not_found():
             "/backend/download/550e8400-e29b-41d4-a716-446655440001"
         )
     assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.anyio
+@patch("main.glob.glob", return_value=["static/550e8400-e29b-41d4-a716-446655440000/test.svg"])
+@patch("main.os.path.exists", return_value=True)
+async def test_download_success_headers(mock_exists, mock_glob):
+    """Download endpoint should return proper Content-Type and Content-Disposition."""
+    # Create a temporary SVG file for FileResponse to read
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".svg", delete=False, mode="w") as f:
+        f.write('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+        tmp_path = f.name
+
+    mock_glob.return_value = [tmp_path]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/backend/download/550e8400-e29b-41d4-a716-446655440000"
+        )
+
+    os.remove(tmp_path)
+    assert response.status_code == 200
+    assert "image/svg+xml" in response.headers["content-type"]
+    assert "attachment" in response.headers["content-disposition"]
 
 
 # --- SSE Progress endpoint tests ---


### PR DESCRIPTION
## Summary
- Set `Content-Disposition: attachment` to force download (prevents inline SVG XSS)
- Set `media_type='image/svg+xml'` explicitly
- Replace inconsistent `JSONResponse` returns with `HTTPException` for error cases
- Add `test_download_success_headers` test verifying correct headers (61 total)

## Test plan
- [x] All 61 backend tests pass
- [x] Download returns `Content-Disposition: attachment`
- [x] Download returns `Content-Type: image/svg+xml`

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)