### PR TITLE
Fix response parsing order in post.ts

### DIFF
--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -56,17 +56,18 @@ const doPost = async (url: string, data: File, preset: string = 'balanced'): Pro
     body: JSON.stringify({ name : name, data : base64, preset }),
   });
 
-  const result = await response.json();
-
   if (!response.ok) {
-    throw new ApiError(
-      response.statusText,
-      response.status,
-      result.detail || result
-    );
+    let detail: Record<string, unknown> = {};
+    try {
+      const errorBody = await response.json();
+      detail = errorBody.detail || errorBody;
+    } catch {
+      detail = { error: response.statusText };
+    }
+    throw new ApiError(response.statusText, response.status, detail);
   }
 
-  return result as ApiResponse;
+  return await response.json() as ApiResponse;
 }
 
 export const Post = async (


### PR DESCRIPTION
## Summary
- Check `response.ok` before attempting `response.json()` to prevent errors on non-JSON error responses
- Add graceful fallback when error response body cannot be parsed as JSON
- Closes #88

## Test plan
- [x] `npm run check` passes (0 errors, 0 warnings)
- [x] `npx vitest run` passes (20/20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)