### PR TITLE
Add fetch timeout with AbortController

### DIFF
--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -45,16 +45,32 @@ const getBase64 = (data: File): Promise<string> => {
   });
 }
 
+export const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
 const doPost = async (url: string, data: File, preset: string = 'balanced'): Promise<ApiResponse> => {
   const name = data.name;
   const base64 = await getBase64(data);
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ name : name, data : base64, preset }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name : name, data : base64, preset }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new ApiError('Request timed out', 0, { error: 'Upload timed out. The file may be too large or the server is unresponsive.' });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (!response.ok) {
     let detail: Record<string, unknown> = {};

--- a/frontend/src/tests/post.test.ts
+++ b/frontend/src/tests/post.test.ts
@@ -98,6 +98,33 @@ describe('Post', () => {
     expect(body.preset).toBe('balanced');
   });
 
+  it('should throw ApiError on fetch abort', async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError')
+    );
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    await expect(Post(file, 'balanced')).rejects.toMatchObject({
+      message: 'Request timed out',
+      status: 0,
+      detail: { error: 'Upload timed out. The file may be too large or the server is unresponsive.' },
+    });
+  });
+
+  it('should pass AbortSignal to fetch', async () => {
+    const mockResponse = { success: true, url: 'http://test/out.svg', filename: 'out.svg' };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse)
+    });
+
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    await Post(file, 'balanced');
+
+    const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('should send file name and base64 data in request body', async () => {
     const mockResponse = { success: true, url: 'http://test/out.svg', filename: 'out.svg' };
 


### PR DESCRIPTION
## Summary
- Add 5-minute timeout to upload requests via AbortController
- Clear "Request timed out" error message on timeout
- Added 2 new tests (abort error handling, signal passing)
- Closes #96

## Test plan
- [x] `npm run check` passes (0 errors, 0 warnings)
- [x] `npx vitest run` passes (22/22 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)