### PR TITLE
Add base64 payload size validation before decoding

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration constants
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
+MAX_BASE64_LENGTH = MAX_FILE_SIZE * 4 // 3 + 100  # Base64 overhead + padding
 ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'}
 CLEANUP_INTERVAL_SECONDS = 600   # Run cleanup every 10 minutes
 FILE_MAX_AGE_SECONDS = 3600      # Delete files older than 1 hour
@@ -42,6 +43,7 @@ ERROR_CODES = {
     'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
     'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
+    'PAYLOAD_TOO_LARGE': f'Base64 payload exceeds the maximum allowed size.',
 }
 
 # Rate limiting
@@ -348,6 +350,13 @@ async def image_processing(request: Request, request_id: str, data: Dict):
             raise HTTPException(
                 status_code=400,
                 detail={'error': 'Malformed data URL: missing base64 content.', 'code': 'MALFORMED_DATA_URL'}
+            )
+
+        if len(img_data) > MAX_BASE64_LENGTH:
+            logger.warning(f"Base64 payload too large: {len(img_data)} chars (max {MAX_BASE64_LENGTH})")
+            raise HTTPException(
+                status_code=413,
+                detail={'error': ERROR_CODES['PAYLOAD_TOO_LARGE'], 'code': 'PAYLOAD_TOO_LARGE'}
             )
 
         try:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -17,6 +17,7 @@ from main import (
     limiter,
     UPLOAD_RATE_LIMIT,
     CONVERSION_TIMEOUT_SECONDS,
+    MAX_BASE64_LENGTH,
 )
 
 
@@ -766,3 +767,17 @@ async def test_upload_strict_base64_rejects_whitespace():
         )
     assert response.status_code == 400
     assert response.json()["detail"]["code"] == "INVALID_BASE64"
+
+
+@pytest.mark.anyio
+async def test_upload_rejects_oversized_base64_payload():
+    """Base64 payload exceeding MAX_BASE64_LENGTH should be rejected before decoding."""
+    oversized_data = "A" * (MAX_BASE64_LENGTH + 1)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+            json={"name": "test.png", "data": f"data:image/png;base64,{oversized_data}"},
+        )
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "PAYLOAD_TOO_LARGE"


### PR DESCRIPTION
## Summary
- Add `MAX_BASE64_LENGTH` constant derived from `MAX_FILE_SIZE`
- Reject oversized base64 payloads with 413 status before attempting decode
- Prevents memory exhaustion from malicious large payloads
- Closes #98

## Test plan
- [x] `python -m pytest tests/ -v` passes (65/65 tests)
- [x] New test: `test_upload_rejects_oversized_base64_payload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)