### PR TITLE
Fix ruff lint errors in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -43,7 +43,7 @@ ERROR_CODES = {
     'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
     'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
-    'PAYLOAD_TOO_LARGE': f'Base64 payload exceeds the maximum allowed size.',
+    'PAYLOAD_TOO_LARGE': 'Base64 payload exceeds the maximum allowed size.',
 }
 
 # Rate limiting

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import base64
 import pytest


### PR DESCRIPTION
## Summary
- Remove extraneous `f` prefix from `PAYLOAD_TOO_LARGE` string (F541)
- Remove unused `asyncio` import from `test_main.py` (F401)

## Test plan
- [x] `ruff check .` passes
- [x] `python -m pytest tests/` passes (65/65 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)