### PR TITLE
Add MIME type validation using file magic numbers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,17 @@ ERROR_CODES = {
     'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
     'PAYLOAD_TOO_LARGE': 'Base64 payload exceeds the maximum allowed size.',
+    'INVALID_FILE_HEADER': 'File content does not match its extension. The file may be corrupted or renamed.',
+}
+
+# Magic number signatures for supported image formats
+IMAGE_SIGNATURES = {
+    '.png': [b'\x89PNG\r\n\x1a\n'],
+    '.jpg': [b'\xff\xd8\xff'],
+    '.jpeg': [b'\xff\xd8\xff'],
+    '.gif': [b'GIF87a', b'GIF89a'],
+    '.bmp': [b'BM'],
+    '.webp': [b'RIFF'],  # Full check: RIFF????WEBP
 }
 
 # Rate limiting
@@ -167,6 +178,35 @@ def sanitize_filename(filename: str) -> str:
             detail={'error': 'Invalid filename.', 'code': 'INVALID_FILENAME'}
         )
     return sanitized
+
+
+def validate_file_header(filename: str, data: bytes) -> None:
+    """
+    Validate that file content matches its extension using magic numbers.
+
+    Raises:
+        HTTPException: If file header doesn't match the extension
+    """
+    file_ext = Path(filename).suffix.lower()
+    signatures = IMAGE_SIGNATURES.get(file_ext)
+    if signatures is None:
+        return  # Extension not in signature map, skip header check
+
+    if not any(data.startswith(sig) for sig in signatures):
+        logger.warning(f"File header mismatch for {filename}: extension {file_ext} "
+                       f"but header bytes {data[:8].hex()}")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
+        )
+
+    # Additional check for WebP: RIFF????WEBP
+    if file_ext == '.webp' and len(data) >= 12 and data[8:12] != b'WEBP':
+        logger.warning(f"File is RIFF but not WebP: {filename}")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
+        )
 
 
 def validate_file(filename: str, file_size: int) -> None:
@@ -368,6 +408,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
             )
 
         validate_file(name, len(decoded_img))
+        validate_file_header(name, decoded_img)
 
         _update_progress(request_id, 'saving', 25)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient, ASGITransport
 from main import (
     app,
     validate_file,
+    validate_file_header,
     _validate_uuid,
     sanitize_filename,
     PRESETS,
@@ -127,6 +128,55 @@ class TestValidateFile:
         validate_file("image.png", 10 * 1024 * 1024)
 
 
+class TestValidateFileHeader:
+    """Tests for magic number / file header validation."""
+
+    def test_valid_png_header(self):
+        data = b'\x89PNG\r\n\x1a\n' + b'\x00' * 100
+        validate_file_header("image.png", data)  # Should not raise
+
+    def test_valid_jpeg_header(self):
+        data = b'\xff\xd8\xff\xe0' + b'\x00' * 100
+        validate_file_header("image.jpg", data)
+
+    def test_valid_gif_header(self):
+        data = b'GIF89a' + b'\x00' * 100
+        validate_file_header("image.gif", data)
+
+    def test_valid_bmp_header(self):
+        data = b'BM' + b'\x00' * 100
+        validate_file_header("image.bmp", data)
+
+    def test_valid_webp_header(self):
+        data = b'RIFF\x00\x00\x00\x00WEBP' + b'\x00' * 100
+        validate_file_header("image.webp", data)
+
+    def test_invalid_png_header(self):
+        data = b'\xff\xd8\xff' + b'\x00' * 100  # JPEG header with .png ext
+        with pytest.raises(HTTPException) as exc_info:
+            validate_file_header("image.png", data)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail['code'] == 'INVALID_FILE_HEADER'
+
+    def test_invalid_jpeg_header(self):
+        data = b'\x89PNG\r\n\x1a\n' + b'\x00' * 100  # PNG header with .jpg ext
+        with pytest.raises(HTTPException) as exc_info:
+            validate_file_header("image.jpg", data)
+        assert exc_info.value.status_code == 400
+
+    def test_text_file_as_png(self):
+        data = b'Hello world this is not an image'
+        with pytest.raises(HTTPException) as exc_info:
+            validate_file_header("fake.png", data)
+        assert exc_info.value.status_code == 400
+
+    def test_riff_but_not_webp(self):
+        data = b'RIFF\x00\x00\x00\x00AVI ' + b'\x00' * 100
+        with pytest.raises(HTTPException) as exc_info:
+            validate_file_header("fake.webp", data)
+        assert exc_info.value.status_code == 400
+
+
 # --- Integration tests for endpoints ---
 
 
@@ -199,7 +249,7 @@ async def test_upload_path_traversal(mock_image_to_svg, mock_getsize):
     # Mock vtracer to avoid actual conversion
     mock_image_to_svg.return_value = "static/550e8400-e29b-41d4-a716-446655440000/passwd.svg"
 
-    img_bytes = b"\x00" * 100
+    img_bytes = b'\x89PNG\r\n\x1a\n' + b"\x00" * 100
     b64 = base64.b64encode(img_bytes).decode()
     data_url = f"data:image/png;base64,{b64}"
 


### PR DESCRIPTION
## Summary
- Validate file content headers (magic numbers) after base64 decoding
- Supports PNG, JPEG, GIF, BMP, and WebP signatures
- Additional RIFF/WEBP subtype check for WebP files
- Prevents renamed files from bypassing format validation
- Closes #103

## Test plan
- [x] `ruff check .` passes
- [x] `python -m pytest tests/` passes (74/74 tests, +9 new)
- New tests: valid/invalid headers for all formats, RIFF-but-not-WebP, text-as-PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)