### PR TITLE
Add SVG output file size limit

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,7 @@ SSE_TIMEOUT_SECONDS = 60              # Max time for SSE progress stream
 PROGRESS_CLEANUP_DELAY_SECONDS = 120   # Delay before cleaning up progress entries
 PROGRESS_MAX_AGE_SECONDS = 300         # Max age for stale progress entries (5 minutes)
 CONVERSION_TIMEOUT_SECONDS = 120       # Max time for a single conversion
+MAX_SVG_SIZE = 50 * 1024 * 1024        # 50MB max SVG output size
 ERROR_CODES = {
     'INVALID_FORMAT': 'File format is not supported. Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF.',
     'FILE_TOO_LARGE': f'File size exceeds the maximum limit of {MAX_FILE_SIZE / (1024 * 1024):.0f}MB.',
@@ -45,6 +46,7 @@ ERROR_CODES = {
     'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
     'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
     'PAYLOAD_TOO_LARGE': 'Base64 payload exceeds the maximum allowed size.',
+    'SVG_TOO_LARGE': 'Generated SVG is too large. Try a simpler image or the "fast" preset.',
     'INVALID_FILE_HEADER': 'File content does not match its extension. The file may be corrupted or renamed.',
 }
 
@@ -469,6 +471,13 @@ async def image_processing(request: Request, request_id: str, data: Dict):
         conversion_time_ms = round((time.monotonic() - convert_start) * 1000)
 
         svg_size = os.path.getsize(output_path)
+        if svg_size > MAX_SVG_SIZE:
+            logger.warning(f"SVG output too large: {svg_size} bytes for request {request_id}")
+            os.remove(output_path)
+            raise HTTPException(
+                status_code=413,
+                detail={'error': ERROR_CODES['SVG_TOO_LARGE'], 'code': 'SVG_TOO_LARGE'}
+            )
         svg_filename = Path(output_path).name
         response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -867,3 +867,30 @@ async def test_upload_rejects_oversized_base64_payload():
         )
     assert response.status_code == 413
     assert response.json()["detail"]["code"] == "PAYLOAD_TOO_LARGE"
+
+
+@pytest.mark.anyio
+@patch("main.vtracer")
+@patch("main.os.makedirs")
+@patch("main.os.path.exists", return_value=False)
+async def test_upload_rejects_oversized_svg_output(mock_exists, mock_makedirs, mock_vtracer):
+    """SVG output exceeding MAX_SVG_SIZE should be rejected."""
+    mock_vtracer.convert_image_to_svg_py = MagicMock()
+
+    png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
+    b64 = base64.b64encode(png_bytes).decode()
+    data_url = f"data:image/png;base64,{b64}"
+
+    # Mock getsize to return a value exceeding MAX_SVG_SIZE
+    with patch("builtins.open", MagicMock()), \
+         patch("main.os.path.getsize", return_value=51 * 1024 * 1024), \
+         patch("main.os.remove") as mock_remove:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+                json={"name": "test.png", "data": data_url},
+            )
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "SVG_TOO_LARGE"
+    mock_remove.assert_called_once()


### PR DESCRIPTION
## Summary
- Add MAX_SVG_SIZE (50MB) constant
- Reject and clean up oversized SVG outputs after conversion
- Returns 413 with SVG_TOO_LARGE error code
- Closes #106

## Test plan
- [x] `ruff check .` passes
- [x] `python -m pytest tests/` passes (78/78 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)