### PR TITLE
Add custom conversion parameters

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -291,12 +291,84 @@ PRESETS = {
 }
 
 
-def image_to_svg(path: str, preset: str = 'balanced') -> str:
+# Allowed custom parameter ranges for validation
+CUSTOM_PARAM_RANGES = {
+    'colormode': {'type': 'enum', 'values': ['color', 'binary']},
+    'mode': {'type': 'enum', 'values': ['spline', 'polygon', 'none']},
+    'filter_speckle': {'type': 'int', 'min': 1, 'max': 128},
+    'color_precision': {'type': 'int', 'min': 1, 'max': 8},
+    'layer_difference': {'type': 'int', 'min': 1, 'max': 256},
+    'corner_threshold': {'type': 'int', 'min': 0, 'max': 180},
+    'length_threshold': {'type': 'float', 'min': 0.0, 'max': 100.0},
+    'max_iterations': {'type': 'int', 'min': 1, 'max': 50},
+    'splice_threshold': {'type': 'int', 'min': 0, 'max': 180},
+    'path_precision': {'type': 'int', 'min': 1, 'max': 10},
+}
+
+
+def validate_custom_params(params: dict) -> dict:
+    """Validate and sanitize custom conversion parameters.
+
+    Returns validated params merged with balanced preset defaults.
+
+    Raises:
+        HTTPException: If any parameter is invalid
+    """
+    base = dict(PRESETS['balanced'])
+    for key, value in params.items():
+        if key not in CUSTOM_PARAM_RANGES:
+            continue  # Ignore unknown keys
+        spec = CUSTOM_PARAM_RANGES[key]
+        if spec['type'] == 'enum':
+            if value not in spec['values']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: {value}. "
+                            f"Allowed: {spec['values']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = value
+        elif spec['type'] == 'int':
+            try:
+                val = int(value)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: must be integer",
+                            'code': 'INVALID_PARAM'}
+                )
+            if val < spec['min'] or val > spec['max']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Value for {key} must be between "
+                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = val
+        elif spec['type'] == 'float':
+            try:
+                val = float(value)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: must be number",
+                            'code': 'INVALID_PARAM'}
+                )
+            if val < spec['min'] or val > spec['max']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Value for {key} must be between "
+                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = val
+    return base
+
+
+def image_to_svg(path: str, params: dict | None = None, preset: str = 'balanced') -> str:
     """
     Convert image to SVG using vtracer for true vectorization.
 
     Args:
         path: Path to the image file to convert
+        params: Custom conversion parameters (overrides preset)
         preset: Conversion preset ('high_quality', 'balanced', 'fast')
 
     Returns:
@@ -306,7 +378,8 @@ def image_to_svg(path: str, preset: str = 'balanced') -> str:
         HTTPException: If conversion fails
     """
     output_path = str(Path(path).with_suffix('.svg'))
-    params = PRESETS.get(preset, PRESETS['balanced'])
+    if params is None:
+        params = PRESETS.get(preset, PRESETS['balanced'])
 
     try:
         logger.info(f"Starting conversion: {path} (preset: {preset})")
@@ -335,10 +408,12 @@ async def health_check() -> JSONResponse:
 
 @app.get('/backend/presets')
 async def get_presets() -> JSONResponse:
-    """Return available conversion presets."""
+    """Return available conversion presets and custom parameter definitions."""
     return JSONResponse({
         'presets': list(PRESETS.keys()),
         'default': 'balanced',
+        'preset_values': PRESETS,
+        'custom_params': CUSTOM_PARAM_RANGES,
     })
 
 
@@ -453,13 +528,18 @@ async def image_processing(request: Request, request_id: str, data: Dict):
 
         # Convert to SVG (run in thread pool to avoid blocking event loop)
         preset = data.get('preset', 'balanced')
-        if preset not in PRESETS:
-            preset = 'balanced'
+        custom_params = data.get('custom_params')
+        if custom_params and isinstance(custom_params, dict):
+            conversion_params = validate_custom_params(custom_params)
+        else:
+            if preset not in PRESETS:
+                preset = 'balanced'
+            conversion_params = None
 
         convert_start = time.monotonic()
         try:
             output_path = await asyncio.wait_for(
-                asyncio.to_thread(image_to_svg, file_path, preset),
+                asyncio.to_thread(image_to_svg, file_path, conversion_params, preset),
                 timeout=CONVERSION_TIMEOUT_SECONDS
             )
         except asyncio.TimeoutError:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -9,6 +9,7 @@ from main import (
     app,
     validate_file,
     validate_file_header,
+    validate_custom_params,
     _validate_uuid,
     sanitize_filename,
     PRESETS,
@@ -546,6 +547,36 @@ class TestPresets:
     def test_fast_less_precise(self):
         assert PRESETS['fast']['color_precision'] < PRESETS['balanced']['color_precision']
         assert PRESETS['fast']['max_iterations'] < PRESETS['balanced']['max_iterations']
+
+
+class TestValidateCustomParams:
+    def test_valid_custom_params(self):
+        params = validate_custom_params({'filter_speckle': 10, 'color_precision': 6})
+        assert params['filter_speckle'] == 10
+        assert params['color_precision'] == 6
+        # Should have defaults for unspecified params
+        assert params['colormode'] == 'color'
+
+    def test_invalid_enum_value(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_custom_params({'colormode': 'invalid'})
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail['code'] == 'INVALID_PARAM'
+
+    def test_out_of_range_int(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_custom_params({'filter_speckle': 999})
+        assert exc_info.value.status_code == 400
+
+    def test_invalid_int_type(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_custom_params({'filter_speckle': 'abc'})
+        assert exc_info.value.status_code == 400
+
+    def test_unknown_keys_ignored(self):
+        params = validate_custom_params({'unknown_key': 'value', 'filter_speckle': 5})
+        assert 'unknown_key' not in params
+        assert params['filter_speckle'] == 5
 
 
 @pytest.mark.anyio

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -47,11 +47,29 @@ const getBase64 = (data: File): Promise<string> => {
 
 export const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
-const doPost = async (url: string, data: File, preset: string = 'balanced'): Promise<ApiResponse> => {
+export interface CustomParams {
+  colormode?: string;
+  mode?: string;
+  filter_speckle?: number;
+  color_precision?: number;
+  layer_difference?: number;
+  corner_threshold?: number;
+  length_threshold?: number;
+  max_iterations?: number;
+  splice_threshold?: number;
+  path_precision?: number;
+}
+
+const doPost = async (url: string, data: File, preset: string = 'balanced', customParams?: CustomParams): Promise<ApiResponse> => {
   const name = data.name;
   const base64 = await getBase64(data);
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+
+  const body: Record<string, unknown> = { name, data: base64, preset };
+  if (customParams) {
+    body.custom_params = customParams;
+  }
 
   let response: Response;
   try {
@@ -60,7 +78,7 @@ const doPost = async (url: string, data: File, preset: string = 'balanced'): Pro
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ name : name, data : base64, preset }),
+      body: JSON.stringify(body),
       signal: controller.signal,
     });
   } catch (error) {
@@ -89,7 +107,8 @@ const doPost = async (url: string, data: File, preset: string = 'balanced'): Pro
 export const Post = async (
   data: File,
   preset: string = 'balanced',
-  onProgress?: (event: ProgressEvent) => void
+  onProgress?: (event: ProgressEvent) => void,
+  customParams?: CustomParams,
 ): Promise<ApiResponse> => {
   const { url, id } = baseURL();
   let eventSource: EventSource | null = null;
@@ -113,7 +132,7 @@ export const Post = async (
       };
     }
 
-    const response = await doPost(url, data, preset);
+    const response = await doPost(url, data, preset, customParams);
     return response;
   } catch (error: unknown) {
     if (error instanceof ApiError) {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
   import JSZip from 'jszip';
   import pngIcon from '$lib/assets/png-icon.png';
-  import { Post, ApiError, type ProgressEvent } from '$lib/post';
+  import { Post, ApiError, type ProgressEvent, type CustomParams } from '$lib/post';
   import { validateFile } from '$lib/validate';
   import { saveAs } from 'file-saver';
 
@@ -30,6 +30,19 @@
   let files: FileList | undefined = $state(undefined);
   let fileStatuses: {[key: string]: FileStatus} = $state({});
   let selectedPreset: string = $state('balanced');
+  let customParams: CustomParams = $state({
+    colormode: 'color',
+    mode: 'spline',
+    filter_speckle: 4,
+    color_precision: 6,
+    layer_difference: 16,
+    corner_threshold: 60,
+    length_threshold: 4.0,
+    max_iterations: 10,
+    splice_threshold: 45,
+    path_precision: 3,
+  });
+  let isCustom = $derived(selectedPreset === 'custom');
   let dragOver: boolean = $state(false);
   let previewUrls: string[] = $state([]);
 
@@ -72,7 +85,7 @@
             progress: evt.progress
           };
         }
-      });
+      }, isCustom ? customParams : undefined);
 
       if (data.success) {
         fileStatuses[key] = {
@@ -239,8 +252,53 @@
       <option value="high_quality" title="Best detail, larger SVG, slower conversion">High Quality</option>
       <option value="balanced" title="Good balance of detail, size, and speed">Balanced</option>
       <option value="fast" title="Fastest conversion, smaller SVG, less detail">Fast</option>
+      <option value="custom" title="Fine-tune conversion parameters">Custom</option>
     </select>
   </div>
+
+  {#if isCustom}
+    <div class="custom-params">
+      <div class="param-row">
+        <label for="cp-filter-speckle">Filter Speckle <span class="param-value">{customParams.filter_speckle}</span></label>
+        <input id="cp-filter-speckle" type="range" min="1" max="128" bind:value={customParams.filter_speckle} />
+      </div>
+      <div class="param-row">
+        <label for="cp-color-precision">Color Precision <span class="param-value">{customParams.color_precision}</span></label>
+        <input id="cp-color-precision" type="range" min="1" max="8" bind:value={customParams.color_precision} />
+      </div>
+      <div class="param-row">
+        <label for="cp-layer-difference">Layer Difference <span class="param-value">{customParams.layer_difference}</span></label>
+        <input id="cp-layer-difference" type="range" min="1" max="256" bind:value={customParams.layer_difference} />
+      </div>
+      <div class="param-row">
+        <label for="cp-corner-threshold">Corner Threshold <span class="param-value">{customParams.corner_threshold}</span></label>
+        <input id="cp-corner-threshold" type="range" min="0" max="180" bind:value={customParams.corner_threshold} />
+      </div>
+      <div class="param-row">
+        <label for="cp-max-iterations">Max Iterations <span class="param-value">{customParams.max_iterations}</span></label>
+        <input id="cp-max-iterations" type="range" min="1" max="50" bind:value={customParams.max_iterations} />
+      </div>
+      <div class="param-row">
+        <label for="cp-path-precision">Path Precision <span class="param-value">{customParams.path_precision}</span></label>
+        <input id="cp-path-precision" type="range" min="1" max="10" bind:value={customParams.path_precision} />
+      </div>
+      <div class="param-row">
+        <label for="cp-mode">Mode</label>
+        <select id="cp-mode" bind:value={customParams.mode} class="select-small">
+          <option value="spline">Spline</option>
+          <option value="polygon">Polygon</option>
+          <option value="none">None</option>
+        </select>
+      </div>
+      <div class="param-row">
+        <label for="cp-colormode">Color Mode</label>
+        <select id="cp-colormode" bind:value={customParams.colormode} class="select-small">
+          <option value="color">Color</option>
+          <option value="binary">Binary</option>
+        </select>
+      </div>
+    </div>
+  {/if}
 
   <div class="buttons">
     <button type="button" class="btn send" onclick={send} disabled={!files || files.length === 0 || isProcessing}>
@@ -430,6 +488,47 @@
     border: 1px solid #ccc;
     font-size: 0.9rem;
     background: #f3f4f6;
+  }
+
+  .custom-params {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem 1.5rem;
+    width: 50%;
+    margin-top: 1rem;
+    padding: 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    background: #f9fafb;
+  }
+
+  .param-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .param-row label {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #374151;
+  }
+
+  .param-value {
+    font-weight: 600;
+    color: #3b82f6;
+  }
+
+  .param-row input[type="range"] {
+    width: 100%;
+  }
+
+  .select-small {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    font-size: 0.8rem;
+    background: white;
   }
 
   .buttons {


### PR DESCRIPTION
## Summary
- Add 'Custom' preset option with slider/select controls for vtracer parameters
- Backend validates custom parameters with type and range checking
- Presets endpoint returns parameter definitions for client use
- Frontend shows parameter panel when Custom is selected
- Closes #107

## Test plan
- [x] `ruff check .` passes
- [x] Backend: 83/83 tests pass (+5 new custom param validation tests)
- [x] Frontend: 22/22 tests pass, svelte-check 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)