### PR TITLE
Add concurrent upload limit and max-width constraint

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -196,7 +196,11 @@
       validEntries.push({ key, file });
     }
 
-    await Promise.all(validEntries.map(({ key, file }) => processFile(key, file)));
+    const CONCURRENCY_LIMIT = 3;
+    for (let i = 0; i < validEntries.length; i += CONCURRENCY_LIMIT) {
+      const batch = validEntries.slice(i, i + CONCURRENCY_LIMIT);
+      await Promise.all(batch.map(({ key, file }) => processFile(key, file)));
+    }
     isProcessing = false;
   }
 
@@ -578,6 +582,7 @@
     align-items: center;
     justify-content: center;
     width: 80vw;
+    max-width: 900px;
     margin: 0 auto;
     margin-top: 20vh;
   }


### PR DESCRIPTION
## Summary
- Limit concurrent uploads to 3 simultaneous (batched `Promise.all`) to prevent server overload with large file sets
- Add `max-width: 900px` to main section for better UX on ultra-wide displays

## Test plan
- [x] svelte-check passes (0 errors, 0 warnings)
- [x] All 22 frontend tests pass

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)