### PR TITLE
Add ALLOWED_ORIGINS to sample.env and Dockerfile HEALTHCHECK

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,4 +13,6 @@ RUN useradd -m appuser && chown -R appuser:appuser /usr/src/app
 USER appuser
 
 EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8000/backend/presets || exit 1
 CMD ["python", "main.py"]

--- a/sample.env
+++ b/sample.env
@@ -17,3 +17,8 @@ FRONTEND_PORT=55030
 # API available at http://{IP}:{BACKEND_PORT}/backend/
 # Swagger docs at http://{IP}:{BACKEND_PORT}/api/docs
 BACKEND_PORT=55031
+
+# CORS allowed origins (comma-separated)
+# Leave unset to allow all origins (default)
+# Example: ALLOWED_ORIGINS=http://localhost:55030,https://myapp.example.com
+# ALLOWED_ORIGINS=


### PR DESCRIPTION
## Summary
- Document `ALLOWED_ORIGINS` env var in `sample.env` with usage examples
- Add Docker `HEALTHCHECK` instruction to backend Dockerfile using `/backend/presets` endpoint

## Test plan
- [x] sample.env has ALLOWED_ORIGINS documentation
- [x] Dockerfile includes HEALTHCHECK directive
- [x] Backend tests still pass (no code changes)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)