### PR TITLE
Consolidate CI deps and add non-root user to frontend Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,19 +25,13 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Run linter
-        run: |
-          pip install ruff
-          ruff check .
+        run: ruff check .
 
       - name: Security audit
-        run: |
-          pip install pip-audit
-          pip-audit -r requirements.txt
+        run: pip-audit -r requirements.txt
 
       - name: Run tests with coverage
-        run: |
-          pip install pytest-cov
-          python -m pytest tests/ -v --cov=. --cov-report=term-missing
+        run: python -m pytest tests/ -v --cov=. --cov-report=term-missing
 
   frontend-test:
     runs-on: ubuntu-latest

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,3 +2,6 @@
 pytest==7.4.3
 anyio==3.7.1
 httpx==0.25.2
+ruff>=0.4.0
+pip-audit>=2.7.0
+pytest-cov>=5.0.0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /home/app
 COPY package*.json ./
 RUN npm install
 COPY ./ ./
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup && chown -R appuser:appgroup /home/app
+USER appuser
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Add `ruff`, `pip-audit`, `pytest-cov` to `requirements-dev.txt` so they're installed once
- Remove redundant `pip install` commands from CI workflow steps (were installing tools already available)
- Add non-root user (`appuser`) to frontend Dockerfile for security parity with backend

## Test plan
- [x] CI workflow steps use tools from requirements-dev.txt
- [x] Frontend Dockerfile adds non-root user before EXPOSE

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)