### PR TITLE
Add preset type validation, logging, and protocol-aware response URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -442,7 +442,7 @@ async def stream_progress(request_id: str):
     if not _validate_uuid(request_id):
         raise HTTPException(
             status_code=400,
-            detail={'error': 'Invalid request_id', 'code': 'INVALID_UUID'}
+            detail={'error': 'Invalid request_id: must be a valid UUID format', 'code': 'INVALID_UUID'}
         )
 
     async def event_generator():
@@ -484,6 +484,13 @@ async def image_processing(request: Request, request_id: str, data: Dict):
             raise HTTPException(
                 status_code=400,
                 detail={'error': ERROR_CODES['MISSING_DATA'], 'code': 'MISSING_DATA'}
+            )
+
+        preset = data.get('preset', DEFAULT_PRESET)
+        if not isinstance(preset, str):
+            raise HTTPException(
+                status_code=400,
+                detail={'error': 'Invalid preset: must be a string', 'code': 'INVALID_PRESET'}
             )
 
         _update_progress(request_id, 'decoding', 10)
@@ -531,13 +538,13 @@ async def image_processing(request: Request, request_id: str, data: Dict):
         original_size = len(decoded_img)
 
         # Convert to SVG (run in thread pool to avoid blocking event loop)
-        preset = data.get('preset', 'balanced')
         custom_params = data.get('custom_params')
         if custom_params and isinstance(custom_params, dict):
             conversion_params = validate_custom_params(custom_params)
         else:
             if preset not in PRESETS:
-                preset = 'balanced'
+                logger.warning(f"Invalid preset '{preset}' for request {request_id}, using default")
+                preset = DEFAULT_PRESET
             conversion_params = None
 
         convert_start = time.monotonic()
@@ -566,7 +573,8 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 detail={'error': ERROR_CODES['SVG_TOO_LARGE'], 'code': 'SVG_TOO_LARGE'}
             )
         svg_filename = Path(output_path).name
-        response_url = f'http://{host}:{port}/static/{request_id}/{svg_filename}'
+        scheme = request.url.scheme
+        response_url = f'{scheme}://{host}:{port}/static/{request_id}/{svg_filename}'
 
         _update_progress(request_id, 'completed', 100)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -646,6 +646,23 @@ async def test_upload_with_invalid_preset_falls_back(mock_exists, mock_makedirs,
 
 
 @pytest.mark.anyio
+async def test_upload_rejects_non_string_preset():
+    png_bytes = b'\x89PNG\r\n\x1a\n' + b'\x00' * 50
+    b64 = base64.b64encode(png_bytes).decode()
+    data_url = f"data:image/png;base64,{b64}"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/backend/upload/550e8400-e29b-41d4-a716-446655440000",
+            json={"name": "test.png", "data": data_url, "preset": 123},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INVALID_PRESET"
+
+
+@pytest.mark.anyio
 async def test_download_invalid_uuid():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- Validate preset type is a string early in request processing, returning 400 for non-string types
- Log warning when invalid preset name silently falls back to default
- Use `request.url.scheme` instead of hardcoded `http://` for response URLs (supports HTTPS proxies)
- Standardize UUID error messages across all endpoints for consistency
- Add test for non-string preset type rejection (84 total backend tests)

## Test plan
- [x] All 84 backend tests pass
- [x] ruff lint passes
- [x] New test verifies non-string preset returns 400 with INVALID_PRESET code

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)