### PR TITLE
Refactor: split backend into modules and add comments

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,18 +1,28 @@
-import json
+"""
+Image-to-SVG Converter API
+
+FastAPI application that accepts image uploads (PNG, JPG, JPEG, WebP, BMP, GIF),
+converts them to SVG using vtracer, and provides download + SSE progress endpoints.
+
+Module structure:
+    modules/config.py      - Constants, env vars, logging
+    modules/validation.py  - File/UUID validation, filename sanitization
+    modules/presets.py     - Conversion presets, custom param validation
+    modules/converter.py   - vtracer wrapper
+    modules/progress.py    - Progress tracking, SSE streaming, cleanup
+"""
 import os
 import glob
 import base64
 import binascii
 import asyncio
 import time
-import uuid
 import logging
+
 import uvicorn
-import vtracer
 from pathlib import Path
 from contextlib import asynccontextmanager
 
-from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -22,117 +32,44 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from typing import Dict
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+# --- Module imports ---
+from modules.config import (
+    host, port, frontend_port,
+    UPLOAD_RATE_LIMIT,
+    MAX_BASE64_LENGTH,
+    MAX_SVG_SIZE,
+    CONVERSION_TIMEOUT_SECONDS,
+    DEFAULT_PRESET,
+    ERROR_CODES,
 )
+from modules.validation import (
+    _validate_uuid,
+    sanitize_filename,
+    validate_file,
+    validate_file_header,
+)
+from modules.presets import (
+    PRESETS,
+    CUSTOM_PARAM_RANGES,
+    validate_custom_params,
+)
+from modules.converter import image_to_svg
+from modules.progress import (
+    _update_progress,
+    event_generator,
+    cleanup_old_files,
+)
+
 logger = logging.getLogger(__name__)
 
-# Configuration constants
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
-MAX_BASE64_LENGTH = MAX_FILE_SIZE * 4 // 3 + 100  # Base64 overhead + padding
-ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'}
-CLEANUP_INTERVAL_SECONDS = 600   # Run cleanup every 10 minutes
-FILE_MAX_AGE_SECONDS = 3600      # Delete files older than 1 hour
-SSE_TIMEOUT_SECONDS = 60              # Max time for SSE progress stream
-PROGRESS_CLEANUP_DELAY_SECONDS = 120   # Delay before cleaning up progress entries
-PROGRESS_MAX_AGE_SECONDS = 300         # Max age for stale progress entries (5 minutes)
-CONVERSION_TIMEOUT_SECONDS = 120       # Max time for a single conversion
-MAX_SVG_SIZE = 50 * 1024 * 1024        # 50MB max SVG output size
-DEFAULT_PRESET = 'balanced'
-ERROR_CODES = {
-    'INVALID_FORMAT': 'File format is not supported. Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF.',
-    'FILE_TOO_LARGE': f'File size exceeds the maximum limit of {MAX_FILE_SIZE / (1024 * 1024):.0f}MB.',
-    'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
-    'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
-    'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
-    'PAYLOAD_TOO_LARGE': 'Base64 payload exceeds the maximum allowed size.',
-    'SVG_TOO_LARGE': 'Generated SVG is too large. Try a simpler image or the "fast" preset.',
-    'INVALID_FILE_HEADER': 'File content does not match its extension. The file may be corrupted or renamed.',
-}
 
-# Magic number signatures for supported image formats
-IMAGE_SIGNATURES = {
-    '.png': [b'\x89PNG\r\n\x1a\n'],
-    '.jpg': [b'\xff\xd8\xff'],
-    '.jpeg': [b'\xff\xd8\xff'],
-    '.gif': [b'GIF87a', b'GIF89a'],
-    '.bmp': [b'BM'],
-    '.webp': [b'RIFF'],  # Full check: RIFF????WEBP
-}
-
-# Rate limiting
-UPLOAD_RATE_LIMIT = "10/minute"
-limiter = Limiter(key_func=get_remote_address)
-
-# Progress tracking for SSE
-progress_store: Dict[str, dict] = {}
-
-# Load environment variables
-load_dotenv()
-
-# Validate required environment variables
-host = os.getenv("HOST")
-port = os.getenv("PORT")
-frontend_port = os.getenv("FRONTEND_PORT")
-
-_REQUIRED_ENV_VARS = {"HOST": host, "PORT": port, "FRONTEND_PORT": frontend_port}
-_missing = [k for k, v in _REQUIRED_ENV_VARS.items() if not v]
-if _missing:
-    logger.warning(f"Missing environment variables: {', '.join(_missing)}. "
-                   "Using defaults (HOST=localhost, PORT=8000, FRONTEND_PORT=3000).")
-    host = host or "localhost"
-    port = port or "8000"
-    frontend_port = frontend_port or "3000"
-
-
-async def cleanup_old_files() -> None:
-    """Background task to periodically delete old files and stale progress entries."""
-    while True:
-        await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
-        try:
-            if not os.path.exists('static'):
-                continue
-            now = time.time()
-            for entry in os.scandir('static'):
-                if not entry.is_dir():
-                    continue
-                entry_path = entry.path
-                if now - entry.stat().st_mtime > FILE_MAX_AGE_SECONDS:
-                    for file in os.scandir(entry_path):
-                        file_path = file.path
-                        try:
-                            os.remove(file_path)
-                            logger.info(f"Deleted old file: {file_path}")
-                        except OSError as e:
-                            logger.error(f"Failed to delete file {file_path}: {e}")
-                    try:
-                        os.rmdir(entry_path)
-                        logger.info(f"Deleted old directory: {entry_path}")
-                    except OSError as e:
-                        logger.error(f"Failed to delete directory {entry_path}: {e}")
-        except Exception as e:
-            logger.error(f"Error during file cleanup: {e}")
-
-        # Clean up stale progress entries
-        try:
-            now_mono = time.monotonic()
-            stale_keys = [
-                k for k, v in progress_store.items()
-                if now_mono - v.get('_updated_at', 0) > PROGRESS_MAX_AGE_SECONDS
-            ]
-            for k in stale_keys:
-                progress_store.pop(k, None)
-            if stale_keys:
-                logger.info(f"Cleaned up {len(stale_keys)} stale progress entries")
-        except Exception as e:
-            logger.error(f"Error during progress cleanup: {e}")
-
+# ============================================================
+# Application setup
+# ============================================================
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Application lifespan manager for startup and shutdown tasks."""
+    """Application lifespan: mount static dir and start background cleanup."""
     if not os.path.exists('static'):
         os.mkdir('static')
     app.mount('/static', StaticFiles(directory='static'), name='static')
@@ -146,12 +83,14 @@ async def lifespan(app: FastAPI):
         pass
 
 
-# Create FastAPI instance
 app = FastAPI(docs_url='/api/docs', lifespan=lifespan)
+
+# Rate limiter
+limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# Origin for CORS
+# CORS: use ALLOWED_ORIGINS env var if set, otherwise derive from host/port
 _allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
 if _allowed_origins_env:
     origins = [o.strip() for o in _allowed_origins_env.split(",") if o.strip()]
@@ -161,7 +100,6 @@ else:
             f'http://{host}:{frontend_port}',
             ]
 
-# Enable CORS
 app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
@@ -171,239 +109,9 @@ app.add_middleware(
         )
 
 
-def _validate_uuid(value: str) -> bool:
-    """Validate that a string is a valid UUID format."""
-    try:
-        uuid.UUID(value)
-        return True
-    except ValueError:
-        return False
-
-
-def sanitize_filename(filename: str) -> str:
-    """
-    Sanitize a user-provided filename to prevent path traversal attacks.
-
-    Strips directory components and leading dots, then validates
-    the result is non-empty.
-
-    Raises:
-        HTTPException: If the filename is empty or invalid after sanitization
-    """
-    # Strip directory components (e.g., ../../etc/passwd -> passwd)
-    sanitized = Path(filename).name
-    # Strip leading dots to prevent hidden files
-    sanitized = sanitized.lstrip('.')
-    if not sanitized:
-        logger.warning(f"Invalid filename after sanitization: {filename!r}")
-        raise HTTPException(
-            status_code=400,
-            detail={'error': 'Invalid filename.', 'code': 'INVALID_FILENAME'}
-        )
-    return sanitized
-
-
-def validate_file_header(filename: str, data: bytes) -> None:
-    """
-    Validate that file content matches its extension using magic numbers.
-
-    Raises:
-        HTTPException: If file header doesn't match the extension
-    """
-    file_ext = Path(filename).suffix.lower()
-    signatures = IMAGE_SIGNATURES.get(file_ext)
-    if signatures is None:
-        return  # Extension not in signature map, skip header check
-
-    if not any(data.startswith(sig) for sig in signatures):
-        logger.warning(f"File header mismatch for {filename}: extension {file_ext} "
-                       f"but header bytes {data[:8].hex()}")
-        raise HTTPException(
-            status_code=400,
-            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
-        )
-
-    # Additional check for WebP: RIFF????WEBP
-    if file_ext == '.webp' and len(data) >= 12 and data[8:12] != b'WEBP':
-        logger.warning(f"File is RIFF but not WebP: {filename}")
-        raise HTTPException(
-            status_code=400,
-            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
-        )
-
-
-def validate_file(filename: str, file_size: int) -> None:
-    """
-    Validate file format and size.
-
-    Raises:
-        HTTPException: If validation fails
-    """
-    file_ext = Path(filename).suffix.lower()
-    if file_ext not in ALLOWED_EXTENSIONS:
-        logger.warning(f"Invalid file format: {filename} (extension: {file_ext})")
-        raise HTTPException(
-            status_code=400,
-            detail={'error': ERROR_CODES['INVALID_FORMAT'], 'code': 'INVALID_FORMAT'}
-        )
-    if file_size > MAX_FILE_SIZE:
-        logger.warning(f"File too large: {filename} ({file_size} bytes)")
-        raise HTTPException(
-            status_code=413,
-            detail={'error': ERROR_CODES['FILE_TOO_LARGE'], 'code': 'FILE_TOO_LARGE'}
-        )
-
-PRESETS = {
-    'high_quality': {
-        'colormode': 'color',
-        'mode': 'spline',
-        'filter_speckle': 2,
-        'color_precision': 8,
-        'layer_difference': 8,
-        'corner_threshold': 60,
-        'length_threshold': 4.0,
-        'max_iterations': 20,
-        'splice_threshold': 45,
-        'path_precision': 5,
-    },
-    'balanced': {
-        'colormode': 'color',
-        'mode': 'spline',
-        'filter_speckle': 4,
-        'color_precision': 6,
-        'layer_difference': 16,
-        'corner_threshold': 60,
-        'length_threshold': 4.0,
-        'max_iterations': 10,
-        'splice_threshold': 45,
-        'path_precision': 3,
-    },
-    'fast': {
-        'colormode': 'color',
-        'mode': 'spline',
-        'filter_speckle': 8,
-        'color_precision': 4,
-        'layer_difference': 32,
-        'corner_threshold': 60,
-        'length_threshold': 4.0,
-        'max_iterations': 5,
-        'splice_threshold': 45,
-        'path_precision': 2,
-    },
-}
-
-
-# Allowed custom parameter ranges for validation
-CUSTOM_PARAM_RANGES = {
-    'colormode': {'type': 'enum', 'values': ['color', 'binary']},
-    'mode': {'type': 'enum', 'values': ['spline', 'polygon', 'none']},
-    'filter_speckle': {'type': 'int', 'min': 1, 'max': 128},
-    'color_precision': {'type': 'int', 'min': 1, 'max': 8},
-    'layer_difference': {'type': 'int', 'min': 1, 'max': 256},
-    'corner_threshold': {'type': 'int', 'min': 0, 'max': 180},
-    'length_threshold': {'type': 'float', 'min': 0.0, 'max': 100.0},
-    'max_iterations': {'type': 'int', 'min': 1, 'max': 50},
-    'splice_threshold': {'type': 'int', 'min': 0, 'max': 180},
-    'path_precision': {'type': 'int', 'min': 1, 'max': 10},
-}
-
-
-def validate_custom_params(params: dict) -> dict:
-    """Validate and sanitize custom conversion parameters.
-
-    Returns validated params merged with balanced preset defaults.
-
-    Raises:
-        HTTPException: If any parameter is invalid
-    """
-    base = dict(PRESETS[DEFAULT_PRESET])
-    for key, value in params.items():
-        if key not in CUSTOM_PARAM_RANGES:
-            continue  # Ignore unknown keys
-        spec = CUSTOM_PARAM_RANGES[key]
-        if spec['type'] == 'enum':
-            if value not in spec['values']:
-                raise HTTPException(
-                    status_code=400,
-                    detail={'error': f"Invalid value for {key}: {value}. "
-                            f"Allowed: {spec['values']}", 'code': 'INVALID_PARAM'}
-                )
-            base[key] = value
-        elif spec['type'] == 'int':
-            try:
-                val = int(value)
-            except (ValueError, TypeError):
-                raise HTTPException(
-                    status_code=400,
-                    detail={'error': f"Invalid value for {key}: must be integer",
-                            'code': 'INVALID_PARAM'}
-                )
-            if val < spec['min'] or val > spec['max']:
-                raise HTTPException(
-                    status_code=400,
-                    detail={'error': f"Value for {key} must be between "
-                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
-                )
-            base[key] = val
-        elif spec['type'] == 'float':
-            try:
-                val = float(value)
-            except (ValueError, TypeError):
-                raise HTTPException(
-                    status_code=400,
-                    detail={'error': f"Invalid value for {key}: must be number",
-                            'code': 'INVALID_PARAM'}
-                )
-            if val < spec['min'] or val > spec['max']:
-                raise HTTPException(
-                    status_code=400,
-                    detail={'error': f"Value for {key} must be between "
-                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
-                )
-            base[key] = val
-    return base
-
-
-def image_to_svg(path: str, params: dict | None = None, preset: str = DEFAULT_PRESET) -> str:
-    """
-    Convert image to SVG using vtracer for true vectorization.
-
-    Args:
-        path: Path to the image file to convert
-        params: Custom conversion parameters (overrides preset)
-        preset: Conversion preset ('high_quality', 'balanced', 'fast')
-
-    Returns:
-        Path to the converted SVG file
-
-    Raises:
-        HTTPException: If conversion fails
-    """
-    output_path = str(Path(path).with_suffix('.svg'))
-    if params is None:
-        params = PRESETS.get(preset, PRESETS[DEFAULT_PRESET])
-
-    try:
-        logger.info(f"Starting conversion: {path} (preset: {preset})")
-        vtracer.convert_image_to_svg_py(
-            path,
-            output_path,
-            **params
-        )
-        logger.info(f"Successfully converted: {path} -> {output_path}")
-        return output_path
-    except Exception as e:
-        logger.error(f"Conversion failed for {path}: {str(e)}", exc_info=True)
-        if os.path.exists(output_path):
-            try:
-                os.remove(output_path)
-            except OSError as remove_err:
-                logger.error(f"Failed to clean up {output_path}: {remove_err}")
-        raise HTTPException(
-            status_code=500,
-            detail={'error': ERROR_CODES['CONVERSION_FAILED'], 'code': 'CONVERSION_FAILED'}
-        )
-
+# ============================================================
+# Routes
+# ============================================================
 
 @app.get('/backend/health')
 async def health_check() -> JSONResponse:
@@ -422,20 +130,6 @@ async def get_presets() -> JSONResponse:
     })
 
 
-def _update_progress(request_id: str, stage: str, progress: int) -> None:
-    """Update progress for a request."""
-    progress_store[request_id] = {
-        'stage': stage,
-        'progress': progress,
-        '_updated_at': time.monotonic(),
-    }
-    if stage in ('completed', 'failed'):
-        asyncio.get_running_loop().call_later(
-            PROGRESS_CLEANUP_DELAY_SECONDS,
-            progress_store.pop, request_id, None
-        )
-
-
 @app.get('/backend/progress/{request_id}')
 async def stream_progress(request_id: str):
     """SSE endpoint to stream conversion progress for a request."""
@@ -445,22 +139,8 @@ async def stream_progress(request_id: str):
             detail={'error': 'Invalid request_id: must be a valid UUID format', 'code': 'INVALID_UUID'}
         )
 
-    async def event_generator():
-        last_stage = None
-        start_time = time.monotonic()
-        while time.monotonic() - start_time < SSE_TIMEOUT_SECONDS:
-            entry = progress_store.get(request_id)
-            if entry and entry['stage'] != last_stage:
-                last_stage = entry['stage']
-                client_entry = {k: v for k, v in entry.items() if not k.startswith('_')}
-                yield f"data: {json.dumps(client_entry)}\n\n"
-                if entry['stage'] in ('completed', 'failed'):
-                    return
-            await asyncio.sleep(0.2)
-        yield f"data: {json.dumps({'stage': 'timeout', 'progress': 0})}\n\n"
-
     return StreamingResponse(
-        event_generator(),
+        event_generator(request_id),
         media_type='text/event-stream',
         headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'}
     )
@@ -470,7 +150,10 @@ async def stream_progress(request_id: str):
 @limiter.limit(UPLOAD_RATE_LIMIT)
 async def image_processing(request: Request, request_id: str, data: Dict):
     """
-    Process uploaded PNG file and convert to SVG.
+    Process an uploaded image file and convert it to SVG.
+
+    Flow: validate request -> decode base64 -> validate file -> save to disk
+          -> convert via vtracer (in thread pool) -> return SVG URL
     """
     if not _validate_uuid(request_id):
         raise HTTPException(
@@ -486,6 +169,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 detail={'error': ERROR_CODES['MISSING_DATA'], 'code': 'MISSING_DATA'}
             )
 
+        # Validate preset type early, before any file processing
         preset = data.get('preset', DEFAULT_PRESET)
         if not isinstance(preset, str):
             raise HTTPException(
@@ -497,6 +181,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
 
         name = sanitize_filename(data['name'])
 
+        # Extract base64 content from data URL (format: "data:<mime>;base64,<content>")
         try:
             img_data = data['data'].split(',')[1]
         except IndexError:
@@ -505,6 +190,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 detail={'error': 'Malformed data URL: missing base64 content.', 'code': 'MALFORMED_DATA_URL'}
             )
 
+        # Check base64 payload size before decoding to prevent memory exhaustion
         if len(img_data) > MAX_BASE64_LENGTH:
             logger.warning(f"Base64 payload too large: {len(img_data)} chars (max {MAX_BASE64_LENGTH})")
             raise HTTPException(
@@ -537,7 +223,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
 
         original_size = len(decoded_img)
 
-        # Convert to SVG (run in thread pool to avoid blocking event loop)
+        # Determine conversion parameters: custom params take priority over preset
         custom_params = data.get('custom_params')
         if custom_params and isinstance(custom_params, dict):
             conversion_params = validate_custom_params(custom_params)
@@ -547,6 +233,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 preset = DEFAULT_PRESET
             conversion_params = None
 
+        # Run conversion in a thread pool to avoid blocking the async event loop
         convert_start = time.monotonic()
         try:
             output_path = await asyncio.wait_for(
@@ -561,6 +248,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
             )
         conversion_time_ms = round((time.monotonic() - convert_start) * 1000)
 
+        # Guard against extremely large SVG output
         svg_size = os.path.getsize(output_path)
         if svg_size > MAX_SVG_SIZE:
             logger.warning(f"SVG output too large: {svg_size} bytes for request {request_id}")
@@ -572,6 +260,8 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 status_code=413,
                 detail={'error': ERROR_CODES['SVG_TOO_LARGE'], 'code': 'SVG_TOO_LARGE'}
             )
+
+        # Build response URL using the request's protocol (supports HTTPS proxies)
         svg_filename = Path(output_path).name
         scheme = request.url.scheme
         response_url = f'{scheme}://{host}:{port}/static/{request_id}/{svg_filename}'
@@ -602,6 +292,7 @@ async def image_processing(request: Request, request_id: str, data: Dict):
 
 @app.get('/backend/download/{request_id}')
 async def get_image(request_id: str):
+    """Download a converted SVG file by request ID."""
     if not _validate_uuid(request_id):
         raise HTTPException(
             status_code=400,
@@ -613,9 +304,12 @@ async def get_image(request_id: str):
     svg_path = glob.glob(f'{request_dir}/*.svg')
     if len(svg_path) == 0:
         raise HTTPException(status_code=404, detail={'error': 'Not found', 'code': 'NOT_FOUND'})
+
+    # Verify the resolved path stays within the expected directory (prevent path traversal)
     resolved = Path(svg_path[0]).resolve()
     if not resolved.is_relative_to(Path(request_dir).resolve()):
         raise HTTPException(status_code=404, detail={'error': 'Not found', 'code': 'NOT_FOUND'})
+
     svg_filename = resolved.name
     return FileResponse(
         str(resolved),
@@ -623,6 +317,10 @@ async def get_image(request_id: str):
         headers={'Content-Disposition': f'attachment; filename="{svg_filename}"'}
     )
 
+
+# ============================================================
+# Entry point
+# ============================================================
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=int(port))

--- a/backend/modules/config.py
+++ b/backend/modules/config.py
@@ -1,0 +1,76 @@
+"""
+Application configuration: constants, environment variables, and logging setup.
+"""
+import os
+import logging
+
+from dotenv import load_dotenv
+
+# --- Logging ---
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+# --- Size & format limits ---
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
+# Base64 encoding expands data by ~4/3; add padding tolerance
+MAX_BASE64_LENGTH = MAX_FILE_SIZE * 4 // 3 + 100
+MAX_SVG_SIZE = 50 * 1024 * 1024  # 50MB max SVG output size
+ALLOWED_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp', '.bmp', '.gif'}
+
+
+# --- Timing constants ---
+
+CLEANUP_INTERVAL_SECONDS = 600          # Run cleanup every 10 minutes
+FILE_MAX_AGE_SECONDS = 3600             # Delete files older than 1 hour
+SSE_TIMEOUT_SECONDS = 60               # Max time for SSE progress stream
+PROGRESS_CLEANUP_DELAY_SECONDS = 120    # Delay before cleaning up finished progress entries
+PROGRESS_MAX_AGE_SECONDS = 300          # Max age for stale progress entries (5 minutes)
+CONVERSION_TIMEOUT_SECONDS = 120        # Max time for a single conversion
+
+
+# --- Rate limiting ---
+
+UPLOAD_RATE_LIMIT = "10/minute"
+
+
+# --- Default preset ---
+
+DEFAULT_PRESET = 'balanced'
+
+
+# --- Structured error messages ---
+
+ERROR_CODES = {
+    'INVALID_FORMAT': 'File format is not supported. Supported formats: PNG, JPG/JPEG, WebP, BMP, GIF.',
+    'FILE_TOO_LARGE': f'File size exceeds the maximum limit of {MAX_FILE_SIZE / (1024 * 1024):.0f}MB.',
+    'CONVERSION_FAILED': 'Failed to convert image to SVG. The image may be corrupted or too complex.',
+    'CONVERSION_TIMEOUT': 'Conversion timed out. The image may be too complex for this preset.',
+    'MISSING_DATA': 'Invalid request data. Please provide both file name and data.',
+    'PAYLOAD_TOO_LARGE': 'Base64 payload exceeds the maximum allowed size.',
+    'SVG_TOO_LARGE': 'Generated SVG is too large. Try a simpler image or the "fast" preset.',
+    'INVALID_FILE_HEADER': 'File content does not match its extension. The file may be corrupted or renamed.',
+}
+
+
+# --- Environment variables ---
+
+load_dotenv()
+
+host = os.getenv("HOST")
+port = os.getenv("PORT")
+frontend_port = os.getenv("FRONTEND_PORT")
+
+_REQUIRED_ENV_VARS = {"HOST": host, "PORT": port, "FRONTEND_PORT": frontend_port}
+_missing = [k for k, v in _REQUIRED_ENV_VARS.items() if not v]
+if _missing:
+    logger.warning(f"Missing environment variables: {', '.join(_missing)}. "
+                   "Using defaults (HOST=localhost, PORT=8000, FRONTEND_PORT=3000).")
+    host = host or "localhost"
+    port = port or "8000"
+    frontend_port = frontend_port or "3000"

--- a/backend/modules/converter.py
+++ b/backend/modules/converter.py
@@ -1,0 +1,59 @@
+"""
+Image-to-SVG conversion using vtracer.
+
+Wraps vtracer.convert_image_to_svg_py with error handling and cleanup.
+Called from a thread pool (asyncio.to_thread) to avoid blocking the event loop.
+"""
+import os
+import logging
+from pathlib import Path
+
+import vtracer
+from fastapi import HTTPException
+
+from modules.config import DEFAULT_PRESET, ERROR_CODES
+from modules.presets import PRESETS
+
+logger = logging.getLogger(__name__)
+
+
+def image_to_svg(path: str, params: dict | None = None, preset: str = DEFAULT_PRESET) -> str:
+    """
+    Convert an image file to SVG using vtracer.
+
+    Args:
+        path: Path to the source image file
+        params: Custom vtracer parameters (overrides preset if provided)
+        preset: Named preset to use when params is None
+
+    Returns:
+        Path to the generated SVG file
+
+    Raises:
+        HTTPException: If conversion fails (cleans up partial output)
+    """
+    output_path = str(Path(path).with_suffix('.svg'))
+    if params is None:
+        params = PRESETS.get(preset, PRESETS[DEFAULT_PRESET])
+
+    try:
+        logger.info(f"Starting conversion: {path} (preset: {preset})")
+        vtracer.convert_image_to_svg_py(
+            path,
+            output_path,
+            **params
+        )
+        logger.info(f"Successfully converted: {path} -> {output_path}")
+        return output_path
+    except Exception as e:
+        logger.error(f"Conversion failed for {path}: {str(e)}", exc_info=True)
+        # Clean up any partial SVG output
+        if os.path.exists(output_path):
+            try:
+                os.remove(output_path)
+            except OSError as remove_err:
+                logger.error(f"Failed to clean up {output_path}: {remove_err}")
+        raise HTTPException(
+            status_code=500,
+            detail={'error': ERROR_CODES['CONVERSION_FAILED'], 'code': 'CONVERSION_FAILED'}
+        )

--- a/backend/modules/presets.py
+++ b/backend/modules/presets.py
@@ -1,0 +1,124 @@
+"""
+Conversion presets and custom parameter validation for vtracer.
+
+Each preset is a dict of vtracer kwargs. Custom params are validated
+against CUSTOM_PARAM_RANGES and merged onto the default preset.
+"""
+from fastapi import HTTPException
+
+from modules.config import DEFAULT_PRESET
+
+# vtracer conversion parameter presets (low speckle = more detail, higher precision = slower)
+PRESETS = {
+    'high_quality': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 2,
+        'color_precision': 8,
+        'layer_difference': 8,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 20,
+        'splice_threshold': 45,
+        'path_precision': 5,
+    },
+    'balanced': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 4,
+        'color_precision': 6,
+        'layer_difference': 16,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 10,
+        'splice_threshold': 45,
+        'path_precision': 3,
+    },
+    'fast': {
+        'colormode': 'color',
+        'mode': 'spline',
+        'filter_speckle': 8,
+        'color_precision': 4,
+        'layer_difference': 32,
+        'corner_threshold': 60,
+        'length_threshold': 4.0,
+        'max_iterations': 5,
+        'splice_threshold': 45,
+        'path_precision': 2,
+    },
+}
+
+# Allowed custom parameter ranges for validation.
+# 'enum' type restricts to a set of string values; 'int'/'float' enforce numeric bounds.
+CUSTOM_PARAM_RANGES = {
+    'colormode': {'type': 'enum', 'values': ['color', 'binary']},
+    'mode': {'type': 'enum', 'values': ['spline', 'polygon', 'none']},
+    'filter_speckle': {'type': 'int', 'min': 1, 'max': 128},
+    'color_precision': {'type': 'int', 'min': 1, 'max': 8},
+    'layer_difference': {'type': 'int', 'min': 1, 'max': 256},
+    'corner_threshold': {'type': 'int', 'min': 0, 'max': 180},
+    'length_threshold': {'type': 'float', 'min': 0.0, 'max': 100.0},
+    'max_iterations': {'type': 'int', 'min': 1, 'max': 50},
+    'splice_threshold': {'type': 'int', 'min': 0, 'max': 180},
+    'path_precision': {'type': 'int', 'min': 1, 'max': 10},
+}
+
+
+def validate_custom_params(params: dict) -> dict:
+    """Validate and sanitize custom conversion parameters.
+
+    Starts from the default preset values, then overrides with
+    validated user-supplied params. Unknown keys are silently ignored.
+
+    Returns:
+        Validated params dict ready for vtracer
+
+    Raises:
+        HTTPException: If any parameter value is invalid
+    """
+    base = dict(PRESETS[DEFAULT_PRESET])
+    for key, value in params.items():
+        if key not in CUSTOM_PARAM_RANGES:
+            continue  # Ignore unknown keys
+        spec = CUSTOM_PARAM_RANGES[key]
+        if spec['type'] == 'enum':
+            if value not in spec['values']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: {value}. "
+                            f"Allowed: {spec['values']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = value
+        elif spec['type'] == 'int':
+            try:
+                val = int(value)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: must be integer",
+                            'code': 'INVALID_PARAM'}
+                )
+            if val < spec['min'] or val > spec['max']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Value for {key} must be between "
+                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = val
+        elif spec['type'] == 'float':
+            try:
+                val = float(value)
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Invalid value for {key}: must be number",
+                            'code': 'INVALID_PARAM'}
+                )
+            if val < spec['min'] or val > spec['max']:
+                raise HTTPException(
+                    status_code=400,
+                    detail={'error': f"Value for {key} must be between "
+                            f"{spec['min']} and {spec['max']}", 'code': 'INVALID_PARAM'}
+                )
+            base[key] = val
+    return base

--- a/backend/modules/progress.py
+++ b/backend/modules/progress.py
@@ -1,0 +1,116 @@
+"""
+Progress tracking for file conversions.
+
+Provides an in-memory store for conversion progress, SSE streaming to clients,
+and periodic cleanup of stale/old entries and static files.
+"""
+import os
+import json
+import time
+import asyncio
+import logging
+from typing import Dict
+
+from modules.config import (
+    CLEANUP_INTERVAL_SECONDS,
+    FILE_MAX_AGE_SECONDS,
+    SSE_TIMEOUT_SECONDS,
+    PROGRESS_CLEANUP_DELAY_SECONDS,
+    PROGRESS_MAX_AGE_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+# In-memory progress store: request_id -> {stage, progress, _updated_at}
+progress_store: Dict[str, dict] = {}
+
+
+def _update_progress(request_id: str, stage: str, progress: int) -> None:
+    """Update progress for a request.
+
+    For terminal stages ('completed', 'failed'), schedules automatic
+    cleanup after PROGRESS_CLEANUP_DELAY_SECONDS.
+    """
+    progress_store[request_id] = {
+        'stage': stage,
+        'progress': progress,
+        '_updated_at': time.monotonic(),
+    }
+    if stage in ('completed', 'failed'):
+        # Schedule delayed removal so the client has time to read the final state
+        asyncio.get_running_loop().call_later(
+            PROGRESS_CLEANUP_DELAY_SECONDS,
+            progress_store.pop, request_id, None
+        )
+
+
+async def event_generator(request_id: str):
+    """SSE event generator that yields progress updates for a request.
+
+    Polls progress_store at 200ms intervals. Terminates when the stage
+    reaches 'completed'/'failed' or the SSE_TIMEOUT_SECONDS is exceeded.
+    Internal fields (prefixed with '_') are filtered from client output.
+    """
+    last_stage = None
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < SSE_TIMEOUT_SECONDS:
+        entry = progress_store.get(request_id)
+        if entry and entry['stage'] != last_stage:
+            last_stage = entry['stage']
+            # Filter out internal fields (e.g., _updated_at) before sending
+            client_entry = {k: v for k, v in entry.items() if not k.startswith('_')}
+            yield f"data: {json.dumps(client_entry)}\n\n"
+            if entry['stage'] in ('completed', 'failed'):
+                return
+        await asyncio.sleep(0.2)
+    yield f"data: {json.dumps({'stage': 'timeout', 'progress': 0})}\n\n"
+
+
+async def cleanup_old_files() -> None:
+    """Background task to periodically delete old static files and stale progress entries.
+
+    Runs every CLEANUP_INTERVAL_SECONDS. Deletes request directories whose
+    modification time exceeds FILE_MAX_AGE_SECONDS, and removes progress
+    entries older than PROGRESS_MAX_AGE_SECONDS.
+    """
+    while True:
+        await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+
+        # Clean up old static files
+        try:
+            if not os.path.exists('static'):
+                continue
+            now = time.time()
+            for entry in os.scandir('static'):
+                if not entry.is_dir():
+                    continue
+                entry_path = entry.path
+                if now - entry.stat().st_mtime > FILE_MAX_AGE_SECONDS:
+                    for file in os.scandir(entry_path):
+                        file_path = file.path
+                        try:
+                            os.remove(file_path)
+                            logger.info(f"Deleted old file: {file_path}")
+                        except OSError as e:
+                            logger.error(f"Failed to delete file {file_path}: {e}")
+                    try:
+                        os.rmdir(entry_path)
+                        logger.info(f"Deleted old directory: {entry_path}")
+                    except OSError as e:
+                        logger.error(f"Failed to delete directory {entry_path}: {e}")
+        except Exception as e:
+            logger.error(f"Error during file cleanup: {e}")
+
+        # Clean up stale progress entries
+        try:
+            now_mono = time.monotonic()
+            stale_keys = [
+                k for k, v in progress_store.items()
+                if now_mono - v.get('_updated_at', 0) > PROGRESS_MAX_AGE_SECONDS
+            ]
+            for k in stale_keys:
+                progress_store.pop(k, None)
+            if stale_keys:
+                logger.info(f"Cleaned up {len(stale_keys)} stale progress entries")
+        except Exception as e:
+            logger.error(f"Error during progress cleanup: {e}")

--- a/backend/modules/validation.py
+++ b/backend/modules/validation.py
@@ -1,0 +1,113 @@
+"""
+Input validation: file format/size checks, UUID validation, filename sanitization,
+and magic-number header verification.
+"""
+import uuid
+import logging
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from modules.config import (
+    ALLOWED_EXTENSIONS,
+    MAX_FILE_SIZE,
+    ERROR_CODES,
+)
+
+logger = logging.getLogger(__name__)
+
+# Magic number signatures for supported image formats.
+# Each extension maps to a list of valid byte prefixes.
+IMAGE_SIGNATURES = {
+    '.png': [b'\x89PNG\r\n\x1a\n'],
+    '.jpg': [b'\xff\xd8\xff'],
+    '.jpeg': [b'\xff\xd8\xff'],
+    '.gif': [b'GIF87a', b'GIF89a'],
+    '.bmp': [b'BM'],
+    '.webp': [b'RIFF'],  # Full check below: RIFF????WEBP
+}
+
+
+def _validate_uuid(value: str) -> bool:
+    """Validate that a string is a valid UUID format."""
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+def sanitize_filename(filename: str) -> str:
+    """
+    Sanitize a user-provided filename to prevent path traversal attacks.
+
+    Strips directory components and leading dots, then validates
+    the result is non-empty.
+
+    Raises:
+        HTTPException: If the filename is empty or invalid after sanitization
+    """
+    # Strip directory components (e.g., ../../etc/passwd -> passwd)
+    sanitized = Path(filename).name
+    # Strip leading dots to prevent hidden files
+    sanitized = sanitized.lstrip('.')
+    if not sanitized:
+        logger.warning(f"Invalid filename after sanitization: {filename!r}")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': 'Invalid filename.', 'code': 'INVALID_FILENAME'}
+        )
+    return sanitized
+
+
+def validate_file(filename: str, file_size: int) -> None:
+    """
+    Validate file extension and size.
+
+    Raises:
+        HTTPException: If extension is unsupported or file exceeds size limit
+    """
+    file_ext = Path(filename).suffix.lower()
+    if file_ext not in ALLOWED_EXTENSIONS:
+        logger.warning(f"Invalid file format: {filename} (extension: {file_ext})")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': ERROR_CODES['INVALID_FORMAT'], 'code': 'INVALID_FORMAT'}
+        )
+    if file_size > MAX_FILE_SIZE:
+        logger.warning(f"File too large: {filename} ({file_size} bytes)")
+        raise HTTPException(
+            status_code=413,
+            detail={'error': ERROR_CODES['FILE_TOO_LARGE'], 'code': 'FILE_TOO_LARGE'}
+        )
+
+
+def validate_file_header(filename: str, data: bytes) -> None:
+    """
+    Validate that file content matches its extension using magic number signatures.
+
+    Prevents renamed files (e.g., a .exe renamed to .png) from being processed.
+
+    Raises:
+        HTTPException: If file header doesn't match the extension
+    """
+    file_ext = Path(filename).suffix.lower()
+    signatures = IMAGE_SIGNATURES.get(file_ext)
+    if signatures is None:
+        return  # Extension not in signature map, skip header check
+
+    if not any(data.startswith(sig) for sig in signatures):
+        logger.warning(f"File header mismatch for {filename}: extension {file_ext} "
+                       f"but header bytes {data[:8].hex()}")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
+        )
+
+    # WebP files are RIFF containers; verify the WEBP subtype at byte offset 8
+    if file_ext == '.webp' and len(data) >= 12 and data[8:12] != b'WEBP':
+        logger.warning(f"File is RIFF but not WebP: {filename}")
+        raise HTTPException(
+            status_code=400,
+            detail={'error': ERROR_CODES['INVALID_FILE_HEADER'], 'code': 'INVALID_FILE_HEADER'}
+        )

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -5,21 +5,21 @@ from unittest.mock import patch, MagicMock
 from fastapi import HTTPException
 from httpx import AsyncClient, ASGITransport
 
-from main import (
-    app,
-    validate_file,
-    validate_file_header,
-    validate_custom_params,
-    _validate_uuid,
-    sanitize_filename,
-    PRESETS,
-    progress_store,
-    _update_progress,
-    limiter,
+from main import app, limiter
+from modules.config import (
     UPLOAD_RATE_LIMIT,
     CONVERSION_TIMEOUT_SECONDS,
     MAX_BASE64_LENGTH,
+    PROGRESS_MAX_AGE_SECONDS,
 )
+from modules.validation import (
+    validate_file,
+    validate_file_header,
+    _validate_uuid,
+    sanitize_filename,
+)
+from modules.presets import PRESETS, validate_custom_params
+from modules.progress import progress_store, _update_progress
 
 
 # --- Unit tests for utility functions ---
@@ -285,7 +285,7 @@ async def test_upload_path_traversal(mock_image_to_svg, mock_getsize):
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -314,7 +314,7 @@ async def test_upload_success(mock_exists, mock_makedirs, mock_vtracer, mock_get
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_jpg_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -341,7 +341,7 @@ async def test_upload_jpg_success(mock_exists, mock_makedirs, mock_vtracer, mock
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_jpeg_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -367,7 +367,7 @@ async def test_upload_jpeg_success(mock_exists, mock_makedirs, mock_vtracer, moc
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_jpg_uppercase_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -424,7 +424,7 @@ async def test_upload_mixed_formats_sequentially(mock_image_to_svg, mock_getsize
 
 
 @pytest.mark.anyio
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_jpg_conversion_failure(mock_exists, mock_makedirs, mock_vtracer):
@@ -437,7 +437,7 @@ async def test_upload_jpg_conversion_failure(mock_exists, mock_makedirs, mock_vt
     data_url = f"data:image/jpeg;base64,{b64}"
 
     with patch("builtins.open", MagicMock()):
-        with patch("main.os.path.exists", side_effect=lambda p: False):
+        with patch("modules.converter.os.path.exists", return_value=False):
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
                 response = await client.post(
@@ -452,7 +452,7 @@ async def test_upload_jpg_conversion_failure(mock_exists, mock_makedirs, mock_vt
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -478,7 +478,7 @@ async def test_upload_webp_success(mock_exists, mock_makedirs, mock_vtracer, moc
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -504,7 +504,7 @@ async def test_upload_bmp_success(mock_exists, mock_makedirs, mock_vtracer, mock
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_gif_success(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -593,7 +593,7 @@ async def test_get_presets():
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -621,7 +621,7 @@ async def test_upload_with_preset(mock_exists, mock_makedirs, mock_vtracer, mock
 
 @pytest.mark.anyio
 @patch("main.os.path.getsize", return_value=2048)
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_with_invalid_preset_falls_back(mock_exists, mock_makedirs, mock_vtracer, mock_getsize):
@@ -788,7 +788,6 @@ class TestUpdateProgress:
             'progress': 50,
             '_updated_at': time_mod.monotonic() - 600,  # 10 minutes ago
         }
-        from main import PROGRESS_MAX_AGE_SECONDS
         now = time_mod.monotonic()
         is_stale = now - progress_store[request_id]['_updated_at'] > PROGRESS_MAX_AGE_SECONDS
         assert is_stale is True
@@ -923,7 +922,7 @@ async def test_upload_rejects_oversized_base64_payload():
 
 
 @pytest.mark.anyio
-@patch("main.vtracer")
+@patch("modules.converter.vtracer")
 @patch("main.os.makedirs")
 @patch("main.os.path.exists", return_value=False)
 async def test_upload_rejects_oversized_svg_output(mock_exists, mock_makedirs, mock_vtracer):

--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -1,3 +1,10 @@
+/**
+ * API client for image-to-SVG conversion.
+ *
+ * Handles file upload via base64-encoded POST, SSE progress streaming,
+ * and request timeout management.
+ */
+
 interface ApiResponse {
   success: boolean;
   url: string;
@@ -36,6 +43,7 @@ const baseURL = (): { url: string; id: string } => {
   return { url: `${base}/backend/upload/${ID}`, id: ID };
 }
 
+/** Read a File as a base64 data URL string (e.g., "data:image/png;base64,...") */
 const getBase64 = (data: File): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -60,6 +68,11 @@ export interface CustomParams {
   path_precision?: number;
 }
 
+/**
+ * Send a file to the backend upload endpoint.
+ * Encodes the file as base64, attaches an AbortController for timeout,
+ * and parses error responses into ApiError instances.
+ */
 const doPost = async (url: string, data: File, preset: string = 'balanced', customParams?: CustomParams): Promise<ApiResponse> => {
   const name = data.name;
   const base64 = await getBase64(data);
@@ -104,6 +117,11 @@ const doPost = async (url: string, data: File, preset: string = 'balanced', cust
   return await response.json() as ApiResponse;
 }
 
+/**
+ * Upload a file for conversion with optional SSE progress tracking.
+ * Opens an EventSource to the progress endpoint before sending the POST,
+ * so the client receives real-time stage/progress updates during conversion.
+ */
 export const Post = async (
   data: File,
   preset: string = 'balanced',

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -88,6 +88,8 @@
   });
   let isCustom = $derived(selectedPreset === 'custom');
   let dragOver: boolean = $state(false);
+  // Memoized blob URLs for file previews. Using a Map avoids creating
+  // duplicate URLs when Svelte re-renders the #each loop.
   let previewUrlMap: Map<File, string> = $state(new Map());
 
   function revokePreviewUrls() {
@@ -123,6 +125,7 @@
     return `${index}:${name}`;
   }
 
+  /** Upload and convert a single file. Updates fileStatuses reactively via SSE progress. */
   async function processFile(key: string, file: File) {
     fileStatuses[key] = { status: 'processing', stage: 'uploading', progress: 0, displayName: file.name };
 
@@ -173,6 +176,10 @@
     }
   }
 
+  /**
+   * Validate all selected files, then upload valid ones in batches of 3
+   * to avoid overwhelming the server with concurrent requests.
+   */
   async function send() {
     if (!files) return;
     isProcessing = true;
@@ -224,6 +231,7 @@
     files = undefined;
   }
 
+  /** Fetch all completed SVGs, bundle them into a ZIP, and trigger browser download. */
   async function download() {
     downloadError = null;
     isDownloading = true;
@@ -265,6 +273,11 @@
     });
   }
 
+  /**
+   * Recursively read all image files from a dropped directory.
+   * Uses the non-standard webkitGetAsEntry API (supported by all major browsers).
+   * readEntries() returns results in batches, so we loop until an empty batch.
+   */
   async function readDirectoryEntries(dirEntry: FileSystemDirectoryEntry): Promise<File[]> {
     const reader = dirEntry.createReader();
     const files: File[] = [];
@@ -287,6 +300,7 @@
     return files;
   }
 
+  /** Convert a File[] to a FileList using DataTransfer (needed for the file input binding). */
   function filesToFileList(fileArray: File[]): FileList {
     const dt = new DataTransfer();
     for (const file of fileArray) {
@@ -295,6 +309,11 @@
     return dt.files;
   }
 
+  /**
+   * Handle drag-and-drop of files or folders.
+   * If any dropped item is a directory, uses webkitGetAsEntry to recursively
+   * extract image files. Otherwise, uses the standard dataTransfer.files.
+   */
   async function handleDrop(e: DragEvent) {
     e.preventDefault();
     dragOver = false;


### PR DESCRIPTION
## Summary
- Split `backend/main.py` (~630 lines) into 5 focused modules under `backend/modules/`: `config.py`, `validation.py`, `presets.py`, `converter.py`, `progress.py`
- `main.py` is now a thin orchestration layer (~250 lines) with clear imports and route definitions
- Added JSDoc comments to complex logic in `frontend/src/lib/post.ts` and `frontend/src/routes/+page.svelte`
- Updated all test imports and mock patch paths to match new module structure

Closes #135

## Test plan
- [x] All 84 backend tests pass
- [x] All 22 frontend tests pass
- [x] Ruff lint passes
- [x] No functional changes — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)