### PR TITLE
Fix: use page protocol instead of hardcoded http://

### DIFF
--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -34,7 +34,8 @@ export interface ProgressEvent {
 const getBackendBase = () => {
   const HOST = import.meta.env.VITE_HOST;
   const backendPORT = import.meta.env.VITE_BACKEND_PORT;
-  return `http://${HOST}:${backendPORT}`;
+  const protocol = typeof window !== 'undefined' ? window.location.protocol : 'http:';
+  return `${protocol}//${HOST}:${backendPORT}`;
 }
 
 const baseURL = (): { url: string; id: string } => {


### PR DESCRIPTION
## Summary
- `getBackendBase()` now uses `window.location.protocol` instead of hardcoded `http://`
- Prevents mixed content errors when served over HTTPS

Closes #137

## Test plan
- [x] All 22 frontend tests pass
- [x] Works for both HTTP and HTTPS contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)