### PR TITLE
Fix: use request Host header for response URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -261,10 +261,12 @@ async def image_processing(request: Request, request_id: str, data: Dict):
                 detail={'error': ERROR_CODES['SVG_TOO_LARGE'], 'code': 'SVG_TOO_LARGE'}
             )
 
-        # Build response URL using the request's protocol (supports HTTPS proxies)
+        # Build response URL using the request's Host header so the browser can reach it
+        # (env var host could be 0.0.0.0 which is unreachable from other machines)
         svg_filename = Path(output_path).name
         scheme = request.url.scheme
-        response_url = f'{scheme}://{host}:{port}/static/{request_id}/{svg_filename}'
+        request_host = request.headers.get('host', f'{host}:{port}')
+        response_url = f'{scheme}://{request_host}/static/{request_id}/{svg_filename}'
 
         _update_progress(request_id, 'completed', 100)
 


### PR DESCRIPTION
## Summary
- Response URL now uses the request's `Host` header instead of env var `host`
- Fixes unreachable SVG preview/download URLs when `HOST=0.0.0.0`
- Falls back to env var if Host header is absent

Closes #138

## Test plan
- [x] All 84 backend tests pass
- [x] URL is correct when accessed from another machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)