### PR TITLE
Fix: align length_threshold slider max with backend

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -420,7 +420,7 @@
       </div>
       <div class="param-row">
         <label for="cp-length-threshold">Length Threshold <span class="param-value">{customParams.length_threshold}</span></label>
-        <input id="cp-length-threshold" type="range" min="0" max="20" step="0.5" bind:value={customParams.length_threshold} />
+        <input id="cp-length-threshold" type="range" min="0" max="100" step="0.5" bind:value={customParams.length_threshold} />
       </div>
       <div class="param-row">
         <label for="cp-max-iterations">Max Iterations <span class="param-value">{customParams.max_iterations}</span></label>


### PR DESCRIPTION
## Summary
- Changed `length_threshold` slider `max` from 20 to 100 to match backend's `CUSTOM_PARAM_RANGES`

Closes #139

## Test plan
- [x] All 22 frontend tests pass
- [x] Slider range now matches backend validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)