### PR TITLE
Fix: remove duplicate fileMap assignment in send()

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -201,7 +201,6 @@
       }
 
       fileStatuses[key] = { status: 'pending', displayName: file.name };
-      fileMap[key] = file;
       validEntries.push({ key, file });
     }
 


### PR DESCRIPTION
## Summary
- Removed redundant `fileMap[key] = file` assignment at line 204
- The first assignment at line 192 already covers all files

Closes #140

## Test plan
- [x] All 22 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)