### PR TITLE
Refactor: use string literal union types for stage and params

### DIFF
--- a/frontend/src/lib/post.ts
+++ b/frontend/src/lib/post.ts
@@ -27,7 +27,7 @@ export class ApiError extends Error {
 }
 
 export interface ProgressEvent {
-  stage: string;
+  stage: 'uploading' | 'decoding' | 'saving' | 'converting' | 'completed' | 'failed' | 'timeout';
   progress: number;
 }
 
@@ -57,8 +57,8 @@ const getBase64 = (data: File): Promise<string> => {
 export const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface CustomParams {
-  colormode?: string;
-  mode?: string;
+  colormode?: 'color' | 'binary';
+  mode?: 'spline' | 'polygon' | 'none';
   filter_speckle?: number;
   color_precision?: number;
   layer_difference?: number;


### PR DESCRIPTION
## Summary
- `ProgressEvent.stage` now typed as `'uploading' | 'decoding' | 'saving' | 'converting' | 'completed' | 'failed' | 'timeout'`
- `CustomParams.colormode` typed as `'color' | 'binary'`
- `CustomParams.mode` typed as `'spline' | 'polygon' | 'none'`

Closes #146

## Test plan
- [x] All 22 frontend tests pass
- [x] svelte-check: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)