### PR TITLE
Fix: footer overlap on mobile by removing position:fixed

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1026,8 +1026,8 @@
   }
 
   .footer {
-    position: fixed;
-    bottom: 3px;
+    margin-top: 2rem;
+    padding-bottom: 0.5rem;
   }
 
   .footer p {


### PR DESCRIPTION
## Summary
- Replaced `position: fixed; bottom: 3px` with `margin-top: 2rem; padding-bottom: 0.5rem`
- Footer now flows naturally after content, preventing overlap on mobile

Closes #147

## Test plan
- [x] All 22 frontend tests pass
- [x] Footer no longer overlaps content on any viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)