### PR TITLE
fix(frontend): fix page.test.ts failures after PR #154 import change

### DIFF
--- a/frontend/src/tests/page.test.ts
+++ b/frontend/src/tests/page.test.ts
@@ -22,6 +22,7 @@ vi.mock('$lib/validate', () => ({
 }));
 
 vi.mock('file-saver', () => ({
+  default: { saveAs: vi.fn() },
   saveAs: vi.fn(),
 }));
 

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom/vitest';
+
+// jsdom does not always provide a working localStorage.
+// Provide a simple in-memory implementation so tests can call
+// localStorage.getItem / setItem / removeItem / clear reliably.
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.clear !== 'function') {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem(key: string) { return store[key] ?? null; },
+    setItem(key: string, value: string) { store[key] = String(value); },
+    removeItem(key: string) { delete store[key]; },
+    clear() { for (const k of Object.keys(store)) delete store[k]; },
+    get length() { return Object.keys(store).length; },
+    key(index: number) { return Object.keys(store)[index] ?? null; },
+  } as Storage;
+}


### PR DESCRIPTION
## Summary
- PR #154 で `file-saver` のインポートが `import { saveAs }` から `import pkg from 'file-saver'` に変更されたが、テストのモックが更新されていなかったため全9テストが失敗していた
- `file-saver` モックに `default` エクスポートを追加して修正
- jsdom 環境での `localStorage` 互換性のためポリフィルを `setup.ts` に追加

## Test plan
- [x] `npm run test` で全31テストがパスすることを確認済み

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)